### PR TITLE
Fix path to first-boot in onboot script

### DIFF
--- a/google-startup-scripts/usr/share/google/onboot
+++ b/google-startup-scripts/usr/share/google/onboot
@@ -129,8 +129,8 @@ function run_command_with_retry() {
 }
 
 function first_boot() {
-  if [[ -x /usr/google/share/first-boot ]]; then
-    /usr/google/share/first-boot
+  if [[ -x /usr/share/google/first-boot ]]; then
+    /usr/share/google/first-boot
   fi
 }
 


### PR DESCRIPTION
The path to `first-boot` is wrong in the `onboot` script.

Customized images that don't include google-compute-daemon (which also
runs first-boot) won't have their SSH host keys regenerated if they
expect google-startup-scripts to handle it.
