### PR TITLE
init.d scripts return properly for Debian.

### DIFF
--- a/google-daemon/etc/init.d/google-address-manager
+++ b/google-daemon/etc/init.d/google-address-manager
@@ -149,3 +149,5 @@ case "$1" in
     exit 3
     ;;
 esac
+
+:

--- a/google-daemon/etc/init/google-accounts-manager-task.conf
+++ b/google-daemon/etc/init/google-accounts-manager-task.conf
@@ -5,4 +5,3 @@ start on starting sshd
 task
 
 exec /usr/share/google/google_daemon/manage_accounts.py --interval=-1
-

--- a/google-startup-scripts/etc/init.d/google
+++ b/google-startup-scripts/etc/init.d/google
@@ -71,3 +71,5 @@ case "$1" in
     exit 3
     ;;
 esac
+
+:

--- a/google-startup-scripts/etc/init.d/google-startup-scripts
+++ b/google-startup-scripts/etc/init.d/google-startup-scripts
@@ -69,3 +69,5 @@ case "$1" in
     exit 3
     ;;
 esac
+
+:

--- a/google-startup-scripts/etc/init/google_run_startup_scripts.conf
+++ b/google-startup-scripts/etc/init/google_run_startup_scripts.conf
@@ -8,4 +8,3 @@ script
   /usr/share/google/run-startup-scripts
   initctl emit --no-wait google-startup-scripts-have-run
 end script
-


### PR DESCRIPTION
Adding the : at the end of the scripts implies exit 0
This is the standard way to terminate a daemon script with success.
