### PR TITLE
Update metadata service version in google daemon and startup scripts

### DIFF
--- a/google-daemon/usr/share/google/google_daemon/address_manager.py
+++ b/google-daemon/usr/share/google/google_daemon/address_manager.py
@@ -36,7 +36,7 @@ import time
 import urllib2
 
 PUBLIC_ENDPOINT_URL_PREFIX = (
-'http://metadata/computeMetadata/v1beta1/instance/network-interfaces/0/forwarded-ips/?recursive=true&alt=text&wait_for_change=true&timeout_sec=60&last_etag=')
+'http://metadata/computeMetadata/v1/instance/network-interfaces/0/forwarded-ips/?recursive=true&alt=text&wait_for_change=true&timeout_sec=60&last_etag=')
 GOOGLE_PROTO_ID = 66  # "GG"
 
 class InputError(Exception):
@@ -88,7 +88,9 @@ class AddressManager(object):
       # If the connection gets abandoned, ensure we don't hang more than
       # 70 seconds.
       url = PUBLIC_ENDPOINT_URL_PREFIX + self.last_etag
-      u = self.urllib2.urlopen(urllib2.Request(url), timeout=70)
+      request = urllib2.Request(url)
+      request.add_unredirected_header('X-Google-Metadata-Request', 'True')
+      u = self.urllib2.urlopen(request, timeout=70)
       addrs_data = u.read()
       headers = u.info().dict
       self.last_etag = headers.get('etag', self.default_last_etag)

--- a/google-startup-scripts/README.md
+++ b/google-startup-scripts/README.md
@@ -35,7 +35,7 @@ Google startup scripts also perform the following actions:
 
     Startup scripts check the value of the instance ID at:
 
-        http://metadata/computeMetadata/v1beta1/instance/id
+        http://metadata/computeMetadata/v1/instance/id
     
     and compares it to the last instance ID the disk booted on.
     

--- a/google-startup-scripts/usr/share/google/boto/boot_setup.py
+++ b/google-startup-scripts/usr/share/google/boto/boot_setup.py
@@ -30,7 +30,7 @@ import textwrap
 import urllib2
 
 NUMERIC_PROJECT_ID_URL=('http://metadata.google.internal/'
-                        'computeMetadata/v1beta1/project/numeric-project-id')
+                        'computeMetadata/v1/project/numeric-project-id')
 SYSTEM_BOTO_CONFIG_TEMPLATE='/etc/boto.cfg.template'
 SYSTEM_BOTO_CONFIG='/etc/boto.cfg'
 AUTH_PLUGIN_DIR='/usr/share/google/boto/boto_plugins'
@@ -39,8 +39,9 @@ AUTH_PLUGIN_DIR='/usr/share/google/boto/boto_plugins'
 def GetNumericProjectId():
   """Get the numeric project ID for this VM."""
   try:
-    req = urllib2.Request(NUMERIC_PROJECT_ID_URL)
-    return urllib2.urlopen(req).read()
+    request = urllib2.Request(NUMERIC_PROJECT_ID_URL)
+    request.add_unredirected_header('X-Google-Metadata-Request', 'True')
+    return urllib2.urlopen(request).read()
   except (urllib2.URLError, urllib2.HTTPError, IOError), e:
     return None
 

--- a/google-startup-scripts/usr/share/google/boto/boto_plugins/compute_auth.py
+++ b/google-startup-scripts/usr/share/google/boto/boto_plugins/compute_auth.py
@@ -21,7 +21,7 @@ from boto.auth_handler import AuthHandler
 from boto.auth_handler import NotReadyToAuthenticate
 
 META_DATA_SERVER_BASE_URL=(
-    'http://metadata.google.internal/computeMetadata/v1beta1')
+    'http://metadata.google.internal/computeMetadata/v1')
 
 SERVICE_ACCOUNT_SCOPES_URL=(META_DATA_SERVER_BASE_URL +
     '/instance/service-accounts/%s/scopes?alt=json')
@@ -57,7 +57,9 @@ class ComputeAuth(AuthHandler):
 
   def __GetJSONMetadataValue(self, url):
     try:
-      data = urllib2.urlopen(url).read()
+      request = urllib2.Request(url)
+      request.add_unredirected_header('X-Google-Metadata-Request', 'True')
+      data = urllib2.urlopen(request).read()
       return json.loads(data)
     except (urllib2.URLError, urllib2.HTTPError, IOError), e:
       return None


### PR DESCRIPTION
Test plan:
- python -m py_compile google-daemon/usr/share/google/google_daemon/address_manager.py 
- python -m py_compile google-startup-scripts/usr/share/google/boto/boot_setup.py 
- python -m py_compile google-startup-scripts/usr/share/google/boto/boto_plugins/compute_auth.py
- Changed config to point to my github fork and ran the builder script to create packages.
- Installed daemon and startup scripts rpm on CentOS and verified it succeeded and files were updated correctly.
- Installed daemon and startup scripts deb on Debian and verified it succeeded and files were updated correctly.
- Created new image with CentOS and Debian using gcimagebundle.
- Uploaded image files to BigStore and created test images.
- Created CentOS and Debian instances with test images and startup scripts.
- Verified startup script output and that instances contained updated scripts.
- Re-ran startup scripts from instances' command line; verified startup script output.
