### PR TITLE
Call sync to ensure critical data makes it to disk

### DIFF
--- a/google-daemon/etc/init.d/google-accounts-manager
+++ b/google-daemon/etc/init.d/google-accounts-manager
@@ -71,6 +71,14 @@ do_start()
   # One-shot run prior to daemonizing.
   $DAEMON --single-pass
 
+  # In case of power outage or hard reboot, ensure that SSH keys have been
+  # written to disk before starting the daemon. At this point the other
+  # Google-specific startup logic will have already occurred, sometimes
+  # including other steps which would be good to write to disk; since syncs are
+  # expensive and we don't want to do it twice during boot, just do it once
+  # here.
+  sync
+
   # Return
   #   0 if daemon has been started
   #   1 if daemon was already running

--- a/google-daemon/etc/init/google-accounts-manager-task.conf
+++ b/google-daemon/etc/init/google-accounts-manager-task.conf
@@ -4,5 +4,15 @@
 start on starting sshd
 task
 
-exec /usr/share/google/google_daemon/manage_accounts.py --single-pass
+script
+  # One-shot run prior to daemonizing (in a different upstart job config file).
+  /usr/share/google/google_daemon/manage_accounts.py --single-pass
 
+  # In case of power outage or hard reboot, ensure that SSH keys have been
+  # written to disk before starting the daemon. At this point the other
+  # Google-specific startup logic will have already occurred, sometimes
+  # including other steps which would be good to write to disk; since syncs are
+  # expensive and we don't want to do it twice during boot, just do it once
+  # here.
+  sync
+end script


### PR DESCRIPTION
To be enhanced later with narrower fsync logic in the accounts daemon
itself when it actually finds a change and writes a new authorized keys
file.
