### PR TITLE
Add disk space check.

### DIFF
--- a/gcimagebundle/gcimagebundlelib/imagebundle.py
+++ b/gcimagebundle/gcimagebundlelib/imagebundle.py
@@ -77,6 +77,10 @@ def SetupArgsParser():
   parser.add_option('-f', '--filesystem', dest='file_system',
                     default=None,
                     help='File system type for the image.')
+  parser.add_option('--skip_disk_space_check', dest='skip_disk_space_check',
+                    default=False, action='store_true',
+                    help='Skip the disk space requirement check.')
+
   return parser
 
 
@@ -167,7 +171,8 @@ def main():
   file_system = GetTargetFilesystem(options, guest_platform)
   logging.info('File System: %s', file_system)
   logging.info('Disk Size: %s bytes', options.fs_size)
-  bundle = block_disk.RootFsRaw(options.fs_size, file_system)
+  bundle = block_disk.RootFsRaw(
+      options.fs_size, file_system, options.skip_disk_space_check)
   bundle.SetTarfile(temp_file_name)
   if options.disk:
     readlink_command = ['readlink', '-f', options.disk]

--- a/gcimagebundle/gcimagebundlelib/tests/image_bundle_test_base.py
+++ b/gcimagebundle/gcimagebundlelib/tests/image_bundle_test_base.py
@@ -72,6 +72,13 @@ class MockHttp(utils.Http):
         return self._instance_response
     raise urllib2.HTTPError
 
+class StatvfsResult:
+  """ A struct for partial os.statvfs result, used to mock the result. """
+
+  def __init__(self, f_bsize, f_blocks, f_bfree):
+    self.f_bsize = f_bsize
+    self.f_blocks = f_blocks
+    self.f_bfree = f_bfree
 
 class ImageBundleTest(unittest.TestCase):
   """ImageBundle Unit Test Base Class."""


### PR DESCRIPTION
gcimagebundle now checks disk free space.  If there is not enough free disk space,
it will abort before copying the files. Currently, the disk space calculation
overestimates the space required.  The user can use --skip_disk_space_check to
disable the disk space check.
