### PR TITLE
Add pauses back to gcimagebundle.

### DIFF
--- a/gcimagebundle/gcimagebundlelib/utils.py
+++ b/gcimagebundle/gcimagebundlelib/utils.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import subprocess
+import time
 import urllib2
 
 
@@ -54,6 +55,7 @@ class LoadDiskImage(object):
       if (len(split_line) > 2 and split_line[0] == 'add'
           and split_line[1] == 'map'):
         devs.append('/dev/mapper/' + split_line[2])
+    time.sleep(2)
     return devs
 
   def __exit__(self, unused_exc_type, unused_exc_value, unused_exc_tb):
@@ -65,6 +67,7 @@ class LoadDiskImage(object):
       unused_exc_tb: unused.
     """
     SyncFileSystem()
+    time.sleep(2)
     kpartx_cmd = ['kpartx', '-d', '-v', '-s', self._file_path]
     RunCommand(kpartx_cmd)
 


### PR DESCRIPTION
Centos 6.5 now requires this hack again.
