### PR TITLE
fixes #48, account manager was not starting on upstart systems

### DIFF
--- a/google-daemon/etc/init/google-accounts-manager-service.conf
+++ b/google-daemon/etc/init/google-accounts-manager-service.conf
@@ -2,8 +2,9 @@
 # task is done.
 #
 #
-start on (stopped google-accounts-manager-task and starting ssh)
-stop on stopping ssh
+start on (stopped google-accounts-manager-task 
+      and (starting ssh or starting sshd))
+stop on (stopping ssh or stopping sshd)
 respawn
 
 exec /usr/share/google/google_daemon/manage_accounts.py

--- a/google-daemon/etc/init/google-accounts-manager-task.conf
+++ b/google-daemon/etc/init/google-accounts-manager-task.conf
@@ -1,7 +1,7 @@
 # google - Run account manager as a one-shot task prior to sshd starting.
 #
 #
-start on starting ssh
+start on (starting ssh or starting sshd)
 task
 
 script


### PR DESCRIPTION
Tested on 13.10
