### PR TITLE
Update block_disk.py

### DIFF
--- a/gcimagebundle/gcimagebundlelib/block_disk.py
+++ b/gcimagebundle/gcimagebundlelib/block_disk.py
@@ -92,7 +92,7 @@ class FsRawDisk(fs_copy.FsCopy):
       # For now we only support disks with a single partition.
       if len(devices) == 0:
         raise RawDiskError(
-            'Device %s should be a disk not a partition!' % self._disk)
+            'Device %s should be a disk not a partition.' % self._disk)
       elif len(devices) != 1:
         raise RawDiskError(
             'Device %s has more than 1 partition. Only devices '


### PR DESCRIPTION
in case you specify gcimagebundle -d /dev/sda1
the message is not leading you to specify a disk, it makes you confused about why a single partition
is not a single partition
