### PR TITLE
fix(google-daemon): use * for the passwd not !

### DIFF
--- a/google-daemon/usr/share/google/google_daemon/utils.py
+++ b/google-daemon/usr/share/google/google_daemon/utils.py
@@ -68,8 +68,24 @@ class System(object):
 
   def UserAdd(self, user, groups):
     logging.info('Creating account %s', user)
+
+    # We must set the crypto passwd via useradd to '*' to make ssh work
+    # on Linux systems without PAM.
+    #
+    # Unfortunately, there is no spec that I can find that defines how
+    # this stuff is used and from the manpage of shadow it says that "!"
+    # or "*" or any other invalid crypt can be used.
+    #
+    # ssh just takes it upon itself to use "!" as its locked account token:
+    # https://github.com/openssh/openssh-portable/blob/master/configure.ac#L705
+    #
+    # If '!' token is used then it simply denies logins:
+    # https://github.com/openssh/openssh-portable/blob/master/auth.c#L151
+    #
+    # To solve the issue make the passwd '*' which is also recognized as
+    # locked but doesn't prevent ssh logins.
     result = self.RunCommand([
-        '/usr/sbin/useradd', user, '-m', '-s', '/bin/bash', '-G',
+        '/usr/sbin/useradd', user, '-m', '-s', '/bin/bash', '-p', '*', '-G',
         ','.join(groups)])
     if self.RunCommandFailed(result, 'Could not create user %s', user):
       return False


### PR DESCRIPTION
useradd defaults to using ! as the "locked" password marker.
Unfortunatly, openssh interprets this to mean that it shouldn't let the
user in via ssh if PAM is missing. Work around this by using the *
marker which also means locked but is allowed by openssh.
