### PR TITLE
feat(accounts): add users to the sudo group by default

### DIFF
--- a/google-daemon/usr/share/google/google_daemon/accounts.py
+++ b/google-daemon/usr/share/google/google_daemon/accounts.py
@@ -76,7 +76,7 @@ class Accounts(object):
     self.urllib2 = urllib2_module
 
     self.default_user_groups = self.GroupsThatExist(
-        ['adm', 'video', 'dip', 'plugdev'])
+        ['adm', 'video', 'dip', 'plugdev', 'sudo'])
 
   def CreateUser(self, username, ssh_keys):
     """Create username on the system, with authorized ssh_keys."""


### PR DESCRIPTION
On CoreOS the sudo group gets passwordless sudo. Add users to this
group.

I don't know how you all would like to handle these sorts of distro changes but I am throwing it out there so we can figure it out.
