### PR TITLE
Only load licenses if running on GCE.

### DIFF
--- a/gcimagebundle/gcimagebundlelib/manifest.py
+++ b/gcimagebundle/gcimagebundlelib/manifest.py
@@ -43,7 +43,8 @@ class ImageManifest(object):
       True Manifest was written to file_path.
       False Manifest was not created.
     """
-    self._LoadLicenses()
+    if utils.IsProviderGCE():
+      self._LoadLicenses()
     if self._IsManifestNeeded():
       with open(file_path, 'w') as manifest_file:
         self._WriteToFile(manifest_file)


### PR DESCRIPTION
We attempt to detect if we are running on GCE two ways:
1. By looking at the BIOS provider.
2. Checking if the metadata server is reachable.

Only load licenses if we can confirm we are running on GCE.
