### PR TITLE
Create diagnostics

### DIFF
--- a/google-startup-scripts/usr/share/google/diagnostics
+++ b/google-startup-scripts/usr/share/google/diagnostics
@@ -1,4 +1,18 @@
 #!/bin/sh
+# Copyright 2013 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # headless usage:
 # gcutil addinstance [instance_name] --metadata=startup-script:'//usr/share/google/diagnostics'
 #


### PR DESCRIPTION
Self diagnosis tool for customers to identify issues with SSH login/accessibility of their instance
also helps the Support Team
