### PR TITLE
Modifies regex to correctly recognize centos-7.

### DIFF
--- a/gcimagebundle/gcimagebundlelib/centos.py
+++ b/gcimagebundle/gcimagebundlelib/centos.py
@@ -44,6 +44,9 @@ class Centos(linux.LinuxPlatform):
     if not lines:
       return (None, None, None, None)
     line0 = lines[0]
+    # Matches both CentOS 6 and CentOS 7 formats.
+    # CentOS 6: CentOS release 6.5 (Final)
+    # CentOS 7: CentOS Linux release 7.0.1406 (Core)
     g = re.match(r'(\S+)( Linux)? release (\d+(\.\d+)+) \(([^)]*)\)', line0)
     if not g:
       return (None, None, None, None)


### PR DESCRIPTION
CentOS 7's /etc/redhat-release outputs:
CentOS Linux release 7.0.1406 (Core)

This modifies the regex to parse this format in addition to the previous
centos-6 format.
