### PR TITLE
Switch expired SSH key log level to debug

### DIFF
--- a/google-daemon/usr/share/google/google_daemon/desired_accounts.py
+++ b/google-daemon/usr/share/google/google_daemon/desired_accounts.py
@@ -113,7 +113,7 @@ def AccountDataToDictionary(data):
       continue
     user, key = split_line
     if KeyHasExpired(key):
-      logging.info(
+      logging.debug(
           'Skipping expired SSH key for user %s: %s', user, key)
       continue
     if not user in usermap:


### PR DESCRIPTION
To avoid spamming the console output.
