### PR TITLE
Do not process accounts with /sbin/nologin as login shell

### DIFF
--- a/google-daemon/usr/share/google/google_daemon/accounts.py
+++ b/google-daemon/usr/share/google/google_daemon/accounts.py
@@ -91,8 +91,11 @@ class Accounts(object):
       self.system.UserAdd(username, self.default_user_groups)
 
     if self.UserExists(username):
+      # Don't try to manage the sshkeys of an account with a shell set to
+      # disable logins.  Helps avoid problems caused by operator and root
+      # sharing a home directory in CentOS and RHEL
       if self.UserNoLogin(username):
-        logging.warning(
+        logging.debug(
             'Not processing account for user %s.  User has /sbin/nologin'
             ' set as login shell', username)
         return


### PR DESCRIPTION
The new logic of processing accounts with ssh keys has interfered with the ability to ssh as root on centos and RHEL images.  Those systems have operator accounts with a homdir of /root, which means that /root/.ssh/authorized_keys triggers processing of the operator account.  This can leave the /root/.ssh/authorized_keys file owned by user operator, and sshd will not root login because the ownership is wrong.  This pull request should skip processing of accounts with /sbin/nologin, which would resolve this issue.
