### PR TITLE
Cleanup systemd services for google-startup-scripts

### DIFF
--- a/google-startup-scripts/usr/lib/systemd/system/google-startup-scripts.service
+++ b/google-startup-scripts/usr/lib/systemd/system/google-startup-scripts.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Google Compute Engine user startup scripts
 After=network.target
+After=google.service
 
 [Service]
 ExecStart=/usr/share/google/run-startup-scripts

--- a/google-startup-scripts/usr/lib/systemd/system/google.service
+++ b/google-startup-scripts/usr/lib/systemd/system/google.service
@@ -1,16 +1,14 @@
 [Unit]
 Description=Google Compute Engine VM initialization
-After=syslog.target
 After=network.target
 After=local-fs.target
 Before=sshd.service
-Requires=syslog.target
 Requires=network.target
 Requires=local-fs.target
 
 [Service]
 ExecStart=/usr/share/google/onboot
-Type=simple
+Type=oneshot
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
syslog.target is obsolete in systemd.

Changes onboot service to oneshot type, which ensures it will fully
execute before running any services dependent on its completion.

Ensures google-startup-scripts run only after onboot service finishes
