### PR TITLE
Add support for xfs

### DIFF
--- a/gcimagebundle/gcimagebundlelib/centos.py
+++ b/gcimagebundle/gcimagebundlelib/centos.py
@@ -18,6 +18,7 @@
 
 
 import os
+import platform
 import re
 
 from gcimagebundlelib import linux
@@ -57,3 +58,9 @@ class Centos(linux.LinuxPlatform):
     super(Centos, self).__init__()
     (self.distribution_codename, _, self.distribution,
      self.distribution_version) = Centos.ParseRedhatRelease()
+
+  def GetPreferredFilesystemType(self):
+    (_,version,_) = platform.linux_distribution()
+    if version.startswith('7'):
+      return 'xfs'
+    return 'ext4'

--- a/gcimagebundle/gcimagebundlelib/rhel.py
+++ b/gcimagebundle/gcimagebundlelib/rhel.py
@@ -34,3 +34,9 @@ class RHEL(linux.LinuxPlatform):
 
   def __init__(self):
     super(RHEL, self).__init__()
+
+  def GetPreferredFilesystemType(self):
+    (_,version,_) = platform.linux_distribution()
+    if version.startswith('7'):
+      return 'xfs'
+    return 'ext4'

--- a/gcimagebundle/gcimagebundlelib/utils.py
+++ b/gcimagebundle/gcimagebundlelib/utils.py
@@ -184,6 +184,9 @@ def MakeFileSystem(dev_path, fs_type, uuid=None):
   RunCommand(mkfs_cmd)
 
   if fs_type is 'xfs':
+    # XFS complains if there is a duplicate UUID so we need to generate a new
+    # one. The new uuid will later be updated in the image's /etc/fstab
+    uuid = RunCommand(['uuidgen']).strip()
     set_uuid_cmd = ['xfs_admin', '-U', uuid, dev_path]
   else:
     set_uuid_cmd = ['tune2fs', '-U', uuid, dev_path]


### PR DESCRIPTION
Uses xfs_admin instead of tune2fs to set a unique uuid.

Makes xfs the default system for EL 7 distributions.
