### PR TITLE
Modifies xfs mount to ignore uuid.

### DIFF
--- a/gcimagebundle/gcimagebundlelib/block_disk.py
+++ b/gcimagebundle/gcimagebundlelib/block_disk.py
@@ -161,7 +161,7 @@ class FsRawDisk(fs_copy.FsCopy):
       if uuid is None:
         raise Exception('Could not get uuid from MakeFileSystem')
       mount_point = tempfile.mkdtemp(dir=self._scratch_dir)
-      with utils.MountFileSystem(devices[0], mount_point):
+      with utils.MountFileSystem(devices[0], mount_point, self._fs_type):
         logging.info('Copying contents')
         self._CopySourceFiles(mount_point)
         self._CopyPlatformSpecialFiles(mount_point)


### PR DESCRIPTION
Often, the bundled image shares the same UUID as the disk where
gcimagebundle is called. For xfs mounts, this causes
a uuid conflict when mounting the new image.

This modifies the mount to ignore the uuid when mounting.
