### PR TITLE
Sets default safe_format_and_mount fs of EL 7 to xfs.

### DIFF
--- a/google-startup-scripts/usr/share/google/safe_format_and_mount
+++ b/google-startup-scripts/usr/share/google/safe_format_and_mount
@@ -23,6 +23,10 @@
 FSCK=fsck.ext4
 MOUNT_OPTIONS="discard,defaults"
 MKFS="mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 -F"
+if grep -q '7\..' /etc/redhat-release; then
+  FSCK=fsck.xfs
+  MKFS=mkfs.xfs
+fi
 
 LOGTAG=safe_format_and_mount
 LOGFACILITY=user


### PR DESCRIPTION
safe_format_and_mount now uses xfs tools by default on EL 7 systems
