### PR TITLE
set up loop to mount

### DIFF
--- a/gcimagebundle/gcimagebundlelib/utils.py
+++ b/gcimagebundle/gcimagebundlelib/utils.py
@@ -50,6 +50,11 @@ class LoadDiskImage(object):
   def __enter__(self):
     """Map disk image as a device."""
     SyncFileSystem()
+
+    # In the new kernel loop is compiled as a module.
+    # set up loop to mount
+    RunCommand(["modprobe", "loop"])
+
     kpartx_cmd = ['kpartx', '-a', '-v', '-s', self._file_path]
     output = RunCommand(kpartx_cmd)
     devs = []


### PR DESCRIPTION
fix for this error:
```
 googlecompute: Error while running ['kpartx', '-a', '-v', '-s', '/tmp/tmp0fJeE9/disk.raw'] return_code = 1
    googlecompute: stdout=
    googlecompute: stderr=mount: could not find any device /dev/loop#Bad address
    googlecompute: can't set up loop
    googlecompute:
    googlecompute: Traceback (most recent call last):
    googlecompute: File "/usr/bin/gcimagebundle", line 28, in <module>
    googlecompute: main()
    googlecompute: File "/usr/bin/gcimagebundle", line 24, in main
    googlecompute: imagebundle.main()
    googlecompute: File "/usr/lib/python2.7/dist-packages/gcimagebundlelib/imagebundle.py", line 211, in main
    googlecompute: (fs_size, digest) = bundle.Bundleup()
    googlecompute: File "/usr/lib/python2.7/dist-packages/gcimagebundlelib/block_disk.py", line 136, in Bundleup
    googlecompute: partition_start, uuid = self._InitializeDiskFileFromDevice(disk_file_path)
    googlecompute: File "/usr/lib/python2.7/dist-packages/gcimagebundlelib/block_disk.py", line 91, in _InitializeDiskFileFromDevice
    googlecompute: with utils.LoadDiskImage(file_path) as devices:
    googlecompute:
    googlecompute:
    googlecompute: File "/usr/lib/python2.7/dist-packages/gcimagebundlelib/utils.py", line 54, in __enter__
    googlecompute: output = RunCommand(kpartx_cmd)
    googlecompute: File "/usr/lib/python2.7/dist-packages/gcimagebundlelib/utils.py", line 364, in RunCommand
    googlecompute: cmd=command)
    googlecompute: subprocess.CalledProcessError: Command '['kpartx', '-a', '-v', '-s', '/tmp/tmp0fJeE9/disk.raw']' returned non-zero exit status 1
```