### PR TITLE
Fixed quoting issue preventing gs matches

### DIFF
--- a/google-startup-scripts/usr/share/google/fetch_script
+++ b/google-startup-scripts/usr/share/google/fetch_script
@@ -61,7 +61,7 @@ function download_url_with_logfile() {
   # Check for the Google Storage URLs:
   # http://<bucket>.storage.googleapis.com/<object>/
   # https://<bucket>.storage.googleapis.com/<object>/
-  if [[ "$url" =~ http[s]?://"${bucket}"\.storage\.googleapis\.com/"${object}" ]];
+  if [[ "$url" =~ http[s]?://${bucket}\.storage\.googleapis\.com/${object} ]];
   then
     log "Downloading url from ${url} to ${dest} using gsutil"
     # Create a url that can be interpreted by gsutil
@@ -74,7 +74,7 @@ function download_url_with_logfile() {
   # The following are deprecated but checked
   # http://commondatastorage.googleapis.com/<bucket>/<object>/
   # https://commondatastorage.googleapis.com/<bucket>/<object>/
-  elif [[ "$url" =~ http[s]?://(commondata)?storage\.googleapis\.com/"${bucket}"/"${object}" ]];
+  elif [[ "$url" =~ http[s]?://(commondata)?storage\.googleapis\.com/${bucket}/${object} ]];
   then
     log "Downloading url from ${url} to ${dest} using gsutil"
     # Create a url that can be interpreted by gsutil

--- a/google-startup-scripts/usr/share/google/run-scripts
+++ b/google-startup-scripts/usr/share/google/run-scripts
@@ -46,7 +46,7 @@ function copy_and_run() {
   cat "${source}" >> "${dest}"
   chmod u+x "${dest}"
   log "Running ${SCRIPT_TYPE} script ${source}"
-  "${dest}" 2>&1 | "${LOG_CMD}"
+  "${dest}" 2>&1 | ${LOG_CMD}
   log "Finished running ${SCRIPT_TYPE} script ${source}"
   rm -f "${dest}"
 }


### PR DESCRIPTION
The quotes around LOG_CMD prevented printing because it should get expanded.

The quotes in the matches were preventing gs matches preventing the scripts from getting copied.
