### PR TITLE
Startup script fetch symmetric to the shutdown script

### DIFF
--- a/google-startup-scripts/usr/share/google/onboot
+++ b/google-startup-scripts/usr/share/google/onboot
@@ -83,8 +83,6 @@ function do_init() {
     ${BOTO_SETUP_SCRIPT} >> ${LOGFILE} 2>&1
   fi
 
-  /usr/share/google/fetch_script ${STARTUP_SCRIPT} startup
-
   return 0
 }
 

--- a/google-startup-scripts/usr/share/google/run-shutdown-scripts
+++ b/google-startup-scripts/usr/share/google/run-shutdown-scripts
@@ -21,24 +21,6 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin
 
 declare -r SHUTDOWN_SCRIPT=/var/run/google.shutdown.script
 
-if [ -n "$1" ]; then
-  declare -r TIMEOUT=$1
-else
-  declare -r TIMEOUT=150
-fi
-
-if [ -x /usr/bin/logger ]; then
-  declare -r LOGGER=/usr/bin/logger
-else
-  declare -r LOGGER=/bin/logger
-fi
-
-LOG_CMD="${LOGGER} -t shutdownscript -p daemon.info"
-
-function log() {
-  echo "$@" | ${LOG_CMD}
-}
-
 # Make sure all udev changes settle before running shutdown scripts.
 udevadm settle
 
@@ -47,7 +29,4 @@ udevadm settle
 # is initiated, irrespective of whether the shutdown script has completed.
 # The shutdown script blocks other shutdown operations from proceeding.
 /usr/share/google/fetch_script ${SHUTDOWN_SCRIPT} shutdown
-timeout ${TIMEOUT} /usr/share/google/run-scripts ${SHUTDOWN_SCRIPT} shutdown
-if [ $? -eq 124 ]; then
-  log "Timed out."
-fi
+/usr/share/google/run-scripts ${SHUTDOWN_SCRIPT} shutdown

--- a/google-startup-scripts/usr/share/google/run-startup-scripts
+++ b/google-startup-scripts/usr/share/google/run-startup-scripts
@@ -23,4 +23,5 @@ declare -r STARTUP_SCRIPT=/var/run/google.startup.script
 # Make sure all udev changes settle before running startup scripts.
 udevadm settle
 
+/usr/share/google/fetch_script ${STARTUP_SCRIPT} startup
 /usr/share/google/run-scripts ${STARTUP_SCRIPT} startup


### PR DESCRIPTION
I moved the script fetch for startup script into the run startup script function so it is symmetric to run shutdown script.
