### PR TITLE
Add dependency to syslog for address manager

### DIFF
--- a/google-daemon/etc/init.d/google-address-manager
+++ b/google-daemon/etc/init.d/google-address-manager
@@ -15,7 +15,7 @@
 #
 ### BEGIN INIT INFO
 # Provides:    google-address-manager
-# Required-Start:    $network
+# Required-Start:    $network $syslog
 # Required-Stop:     $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
Address manager calls system.MakeLoggingHandler, which requires /dev/log to be created, which isn't guaranteed by this startup script. Adding an explicit dependency to syslog here prevents a race which can cause address manager to fail to start.
