### PR TITLE
Multiple first-boot fixes

### DIFF
--- a/google-startup-scripts/usr/share/google/first-boot
+++ b/google-startup-scripts/usr/share/google/first-boot
@@ -86,11 +86,3 @@ fi
 
 # Make a per-instance data directory.
 mkdir -p ${PREFIX}/var/lib/google/per-instance/${INSTANCE_ID}
-
-# Run system updates.
-if [[ -f ${PREFIX}/etc/debian_version ]]; then
-  # Update packages for apt-get.
-  if [[ -x ${PREFIX}/usr/bin/apt-get ]]; then
-    ${PREFIX}/usr/bin/apt-get -q -y --force-yes update
-  fi
-fi

--- a/google-startup-scripts/usr/share/google/regenerate-host-keys
+++ b/google-startup-scripts/usr/share/google/regenerate-host-keys
@@ -55,10 +55,14 @@ generate_key() {
 
 regenerate_host_keys() {
   log "Regenerating SSH Host Keys for: $new_ip_address (previously $old_ip_address)."
-  rm -f /etc/ssh/ssh_host_key  # SSH1 RSA key.
-  generate_key rsa /etc/ssh/ssh_host_rsa_key
-  generate_key dsa /etc/ssh/ssh_host_dsa_key
-  generate_key ecdsa /etc/ssh/ssh_host_ecdsa_key
+  rm -f /etc/ssh/ssh_host_key /etc/ssh_host_key.pub # SSH1 RSA key.
+  for key_file in /etc/ssh/ssh_host_*_key; do
+    # Parse out the type of key, matching the * in the for loop command above.
+    key_type=$(basename "${key_file}" _key)
+    key_type=${key_type#ssh_host_}
+
+    generate_key "${key_type}" "${key_file}"
+  done
   # Allow sshd to come up if we were suppressing it.
   if [[ $(cat /etc/ssh/sshd_not_to_be_run 2>/dev/null) == "GOOGLE" ]]; then
     rm -f /etc/ssh/sshd_not_to_be_run


### PR DESCRIPTION
- Remove apt-get update, to avoid conflicting with users who adopt
  cloud-init (which also does this). It was broken for a long time so
  users are not typically expecting us to handle this at the moment.
- Generalize SSH host key regeneration to handle all types which are
  already present in the image (the old code missed some newer elliptic
  curve types), and more completely remove all traces of any SSH1 RSA
  key (those are insecure).
