### PR TITLE
Update fetch_script to give better diagnostics

### DIFF
--- a/google-startup-scripts/usr/share/google/fetch_script
+++ b/google-startup-scripts/usr/share/google/fetch_script
@@ -85,7 +85,7 @@ function download_url_with_logfile() {
   # Unauthenticated download of the object.
   log "Downloading url from ${url} to ${dest} using curl"
   curl --max-time "${CURL_TIMEOUT}" --retry "${CURL_RETRY_LIMIT}" \
-    2> "${logfile}" -o "${dest}" -- "${url}" && return 0;
+    2>> "${logfile}" -o "${dest}" -- "${url}" && return 0;
 
   log "Failed to download $url"
   return 1


### PR DESCRIPTION
If "gsutil cp" fails, then its output will be overwritten at the end by the curl invocation, providing no diagnostics. Append curl's output instead, so the gsutil error will be visible as well as the potentially useless "protocol gs not supported" error message from curl.
