### PR TITLE
Removed udevadm settle from shutdown script

### DIFF
--- a/google-startup-scripts/usr/share/google/run-shutdown-scripts
+++ b/google-startup-scripts/usr/share/google/run-shutdown-scripts
@@ -21,9 +21,6 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin
 
 declare -r SHUTDOWN_SCRIPT=/var/run/google.shutdown.script
 
-# Make sure all udev changes settle before running shutdown scripts.
-udevadm settle
-
 # NOTE
 # Make sure that the shutdown script completes within 90 seconds, so
 # that the OS has time to complete its shutdown, including flushing


### PR DESCRIPTION
Fixes a bug where some instances take 2 minutes to shutdown regardless of shutdown scripts.
