### PR TITLE
Fix set-hostname under Debian Jessie.

### DIFF
--- a/google-startup-scripts/usr/share/google/set-hostname
+++ b/google-startup-scripts/usr/share/google/set-hostname
@@ -1,4 +1,3 @@
-#! /bin/bash
 # Copyright 2013 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +14,7 @@
 
 # Deal with a new hostname assignment.
 
-if [[ -n "$new_host_name" && -n "$new_ip_address" ]]; then
+if [ -n "$new_host_name" -a -n "$new_ip_address" ]; then
   # Delete entries with new_host_name or new_ip_address in /etc/hosts.
   sed -i '/Added by Google/d' /etc/hosts
 
@@ -33,10 +32,9 @@ fi
 # As a result, we set the host name in all circumstances here, to the truncated
 # unqualified domain name.
 
-if [[ -n "$new_host_name" ]]; then
+if [ -n "$new_host_name" ]; then
   hostname ${new_host_name%%.*}
 
   # Let syslogd know we've changed the hostname.
   pkill -HUP syslogd
 fi
-

--- a/google-startup-scripts/usr/share/google/set-hostname
+++ b/google-startup-scripts/usr/share/google/set-hostname
@@ -14,7 +14,7 @@
 
 # Deal with a new hostname assignment.
 
-if [ -n "$new_host_name" -a -n "$new_ip_address" ]; then
+if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then
   # Delete entries with new_host_name or new_ip_address in /etc/hosts.
   sed -i '/Added by Google/d' /etc/hosts
 


### PR DESCRIPTION
This script is intended to be used as a dhclient exit hook, sourced (not executed) by `/sbin/dhclient-script`.

The version of `dhclient-script` included in Debian Wheezy uses `/bin/bash` as the shell to run these rather than, as documented, `/bin/sh` (that is, dash).  This is fixed in Jessie, but that fix breaks this script, which depends upon bash.

This change fixes the script to work under dash and bash equally, and also removes the executable bit (as the script is intended to be sourced, not executed directly, and having an executable script with a shebang line just confuses the issue).