### PR TITLE
Update safe_format_and_mount

### DIFF
--- a/google-startup-scripts/usr/share/google/safe_format_and_mount
+++ b/google-startup-scripts/usr/share/google/safe_format_and_mount
@@ -23,12 +23,14 @@
 FSCK=fsck.ext4
 MOUNT_OPTIONS="discard,defaults"
 MKFS="mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 -F"
-if grep -q '6\..' /etc/redhat-release; then
-  # lazy_journal_init is not recognized in redhat 6
-  MKFS="mkfs.ext4 -E lazy_itable_init=0 -F"
-elif grep -q '7\..' /etc/redhat-release; then
-  FSCK=fsck.xfs
-  MKFS=mkfs.xfs
+if [ -f /etc/redhat-release ]; then
+  if grep -q '6\..' /etc/redhat-release; then
+    # lazy_journal_init is not recognized in redhat 6
+    MKFS="mkfs.ext4 -E lazy_itable_init=0 -F"
+  elif grep -q '7\..' /etc/redhat-release; then
+    FSCK=fsck.xfs
+    MKFS=mkfs.xfs
+  fi
 fi
 
 LOGTAG=safe_format_and_mount


### PR DESCRIPTION
Script deployed on multiple OS, so not specific to redhat.
Before this commit, two tests are made on a non-existent file ; resulting is an error displayed in stdout.