### PR TITLE
Remove temp files when move operation fails

### DIFF
--- a/google-daemon/usr/share/google/google_daemon/accounts.py
+++ b/google-daemon/usr/share/google/google_daemon/accounts.py
@@ -414,8 +414,14 @@ class Accounts(object):
       if available_space < required_space:
         raise IOError('Disk is too full')
 
-    # Override the old authorized keys file with the new one.
-    self.system.MoveFile(new_keys_path, authorized_keys_file)
+    try:
+      # Override the old authorized keys file with the new one.
+      self.system.MoveFile(new_keys_path, authorized_keys_file)
+    finally:
+      try:
+        self.system.DeleteFile(new_keys_path)
+      except:
+        pass
 
     # Make sure the authorized_keys_file has the right perms (u+rw).
     self.os.chmod(authorized_keys_file, 0600)

--- a/google-daemon/usr/share/google/google_daemon/utils.py
+++ b/google-daemon/usr/share/google/google_daemon/utils.py
@@ -66,6 +66,9 @@ class System(object):
   def CreateTempFile(self, delete=True):
     return tempfile.NamedTemporaryFile(delete=delete)
 
+  def DeleteFile(self, name):
+    return os.remove(name)
+
   def UserAdd(self, user, groups):
     logging.info('Creating account %s', user)
 


### PR DESCRIPTION
To write authorized_keys files into users' home directories
account manager first creates a temp file in /tmp and then moves
that file. Move operation can fail for various reasons (e.g.
read-only filesystem, out of space, etc). When this happens account
manager will leave stale temp files.
This change fixes this by unconditionally removing the temp file
after the move attempt.