### PR TITLE
Remove unused parameter for Python 3 compatibility

### DIFF
--- a/google-startup-scripts/usr/share/google/boto/boto_plugins/compute_auth.py
+++ b/google-startup-scripts/usr/share/google/boto/boto_plugins/compute_auth.py
@@ -61,7 +61,7 @@ class ComputeAuth(AuthHandler):
       request.add_unredirected_header('Metadata-Flavor', 'Google')
       data = urllib2.urlopen(request).read()
       return json.loads(data)
-    except (urllib2.URLError, urllib2.HTTPError, IOError), e:
+    except (urllib2.URLError, urllib2.HTTPError, IOError):
       return None
 
   def __GetGSScopes(self):


### PR DESCRIPTION
smart_open attempts to import this module. This will raise a syntax error and fail with several packages such as [gensim](https://pypi.python.org/pypi/gensim)