### PR TITLE
Adding /usr/local/bin to path before gsutil call for sudo-ing Redhat users

### DIFF
--- a/gcimagebundle/gcimagebundlelib/imagebundle.py
+++ b/gcimagebundle/gcimagebundlelib/imagebundle.py
@@ -236,6 +236,11 @@ def main():
     else:
       output_bucket = 'gs://%s/%s' % (
           bucket, os.path.basename(output_file))
+
+  # /usr/local/bin not in redhat root PATH by default
+  if '/usr/local/bin' not in os.environ['PATH']:
+    os.environ['PATH'] += ':/usr/local/bin'
+
     # TODO: Consider using boto library directly.
     cmd = ['gsutil', 'cp', output_file, output_bucket]
     retcode = subprocess.call(cmd)

--- a/gcimagebundle/gcimagebundlelib/imagebundle.py
+++ b/gcimagebundle/gcimagebundlelib/imagebundle.py
@@ -241,19 +241,19 @@ def main():
   if '/usr/local/bin' not in os.environ['PATH']:
     os.environ['PATH'] += ':/usr/local/bin'
 
-    # TODO: Consider using boto library directly.
-    cmd = ['gsutil', 'cp', output_file, output_bucket]
-    retcode = subprocess.call(cmd)
-    if retcode != 0:
-      logging.critical('Failed to copy image to bucket. '
-                       'gsutil returned %d. To retry, run the command: %s',
-                       retcode, ' '.join(cmd))
+  # TODO: Consider using boto library directly.
+  cmd = ['gsutil', 'cp', output_file, output_bucket]
+  retcode = subprocess.call(cmd)
+  if retcode != 0:
+    logging.critical('Failed to copy image to bucket. '
+                     'gsutil returned %d. To retry, run the command: %s',
+                     retcode, ' '.join(cmd))
 
-      return -1
-    logging.info('Uploaded image to %s', output_bucket)
+    return -1
+  logging.info('Uploaded image to %s', output_bucket)
 
-    # If we've uploaded, then we can remove the local file.
-    os.remove(output_file)
+  # If we've uploaded, then we can remove the local file.
+  os.remove(output_file)
 
   if options.cleanup:
     shutil.rmtree(scratch_dir)


### PR DESCRIPTION
User on redhat had an issue where "gcimagebundle -b <bucket>" would fail with a misleading error when run from the prompt with "sudo bash" on Redhat (works fine on Debian, didn't try with other OS's).

This adds gsutil's default location to PATH to avoid future confusion.