### PR TITLE
- Improve security for temporary key location

### DIFF
--- a/google-startup-scripts/usr/share/google/regenerate-host-keys
+++ b/google-startup-scripts/usr/share/google/regenerate-host-keys
@@ -37,7 +37,8 @@ sshd_cmd() {
 generate_key() {
   local key_type=$1
   local key_dest=$2
-  local tmp_file="/tmp/keyfile.$$";
+  local tmp_dir=$(mktemp -d /tmp/keystore.XXXXXXXX)
+  local tmp_file="/${tmp_dir}/keyfile.$$";
   local log_file=$(mktemp);
   log "Regenerating sshd key ${key_dest}"
   ssh-keygen -N '' -t ${key_type} -f ${tmp_file} > ${log_file} 2>&1
@@ -49,7 +50,7 @@ generate_key() {
     log "Could not create sshd key ${key_dest}"
     log "$(cat ${log_file})"
   fi
-  rm -f ${tmp_file}
+  rm -rf ${tmp_dir}
   rm -f ${log_file}
 }
 


### PR DESCRIPTION
  + For host key regeneration the temporary location is not sufficiently
    random as it only uses the process ID as unique identifier. This is to
    a certain extend predictable. Therefore a symlink can be used to over
    write the host key files even if that may not be the intention. The
    change places the temporary key files into a directory with a random
    name, thus eliminating the risk.