### PR TITLE
Change startup script KillMode for subprocesses.

### DIFF
--- a/google-startup-scripts/usr/lib/systemd/system/google-startup-scripts.service
+++ b/google-startup-scripts/usr/lib/systemd/system/google-startup-scripts.service
@@ -6,6 +6,7 @@ Wants=local-fs.target network-online.target network.target
 
 [Service]
 ExecStart=/usr/share/google/run-startup-scripts
+KillMode=process
 Type=oneshot
 
 [Install]


### PR DESCRIPTION
This should prevent subprocesses started by startup scripts from getting
killed.