### PR TITLE
fix url for fetching instance id

### DIFF
--- a/google-startup-scripts/usr/share/google/onboot
+++ b/google-startup-scripts/usr/share/google/onboot
@@ -66,7 +66,7 @@ function get_metadata_value() {
 }
 
 function do_environment() {
-  echo "INSTANCE_ID=$(get_metadata_value instance-id)" > ${GOOGLE_ENVIRONMENT}
+  echo "INSTANCE_ID=$(get_metadata_value id)" > ${GOOGLE_ENVIRONMENT}
 }
 
 function do_init() {


### PR DESCRIPTION
The instance-id is accessible from URL "http://metadata.google.internal/computeMetadata/v1/instance/id" and not "http://metadata.google.internal/computeMetadata/v1/instance/instance-id".