### PR TITLE
Add python3 compability to boto compute_auth.py

### DIFF
--- a/google-startup-scripts/usr/share/google/boto/boto_plugins/compute_auth.py
+++ b/google-startup-scripts/usr/share/google/boto/boto_plugins/compute_auth.py
@@ -15,7 +15,12 @@
 """Authentication module for using Google Compute service accounts."""
 
 import json
-import urllib2
+
+try:
+  from urllib2 import Request, urlopen, URLError, HTTPError
+except ImportError:
+  from urllib.request import Request, urlopen
+  from urllib.error import URLError, HTTPError
 
 from boto.auth_handler import AuthHandler
 from boto.auth_handler import NotReadyToAuthenticate
@@ -57,11 +62,11 @@ class ComputeAuth(AuthHandler):
 
   def __GetJSONMetadataValue(self, url):
     try:
-      request = urllib2.Request(url)
+      request = Request(url)
       request.add_unredirected_header('Metadata-Flavor', 'Google')
-      data = urllib2.urlopen(request).read()
+      data = urlopen(request).read()
       return json.loads(data)
-    except (urllib2.URLError, urllib2.HTTPError, IOError):
+    except (URLError, HTTPError, IOError):
       return None
 
   def __GetGSScopes(self):


### PR DESCRIPTION
Default boto configuration on Google Compute Engine is broken when using Python3 and service accounts. Boto automatically includes /etc/boto.cfg which includes compute_auth.py (which is Python2 only). This pull request makes compute_auth.py Python 2+3 safe. 

This relates to issues found on the web, such as https://github.com/travis-ci/travis-ci/issues/5246 and 
https://github.com/boto/boto/issues/3263

This is an extension of commit https://github.com/GoogleCloudPlatform/compute-image-packages/commit/d322487a971a9aa84c125bb7617a66c2bc6307d4