### PR TITLE
Default users on ubuntu should be in the lxd group

### DIFF
--- a/google-daemon/usr/share/google/google_daemon/accounts.py
+++ b/google-daemon/usr/share/google/google_daemon/accounts.py
@@ -76,7 +76,7 @@ class Accounts(object):
     self.urllib2 = urllib2_module
 
     self.default_user_groups = self.GroupsThatExist(
-        ['adm', 'video', 'dip', 'plugdev', 'sudo'])
+        ['adm', 'video', 'dip', 'plugdev', 'sudo', 'lxd'])
 
   def UpdateUser(self, username, ssh_keys):
     """Create username on the system, with authorized ssh_keys."""


### PR DESCRIPTION
lxd is a core part of the Ubuntu cloud experience, so users should be in the lxd group.