### PR TITLE
Escape user in IsUserSudoerEntry re

### DIFF
--- a/google-daemon/usr/share/google/google_daemon/accounts.py
+++ b/google-daemon/usr/share/google/google_daemon/accounts.py
@@ -45,7 +45,7 @@ def IsUserSudoerInLines(user, sudoer_lines):
   """Return whether the user has an entry in the sudoer lines."""
 
   def IsUserSudoerEntry(line):
-    return re.match(r'^%s\s+' % user, line)
+    return re.match(r'^%s\s+' % re.escape(user), line)
 
   return filter(IsUserSudoerEntry, sudoer_lines)
 


### PR DESCRIPTION
The re for the filter does not escape the regular expression, so if a user name has something like a dot, this re will have an unintended match causing #218 