### PR TITLE
Improve and fix the sysvinit guest configs.

### DIFF
--- a/google_compute_engine/instance_setup/instance_setup.py
+++ b/google_compute_engine/instance_setup/instance_setup.py
@@ -37,7 +37,8 @@ class InstanceSetup(object):
 
   def __init__(self):
     facility = logging.handlers.SysLogHandler.LOG_DAEMON
-    self.logger = logger.Logger(name='instance-setup', facility=facility)
+    self.logger = logger.Logger(
+        name='instance-setup', console=False, facility=facility)
     self.watcher = metadata_watcher.MetadataWatcher(logger=self.logger)
     self.metadata_dict = None
     self.instance_config = instance_config.InstanceConfig()

--- a/google_compute_engine/instance_setup/tests/instance_setup_test.py
+++ b/google_compute_engine/instance_setup/tests/instance_setup_test.py
@@ -53,7 +53,8 @@ class InstanceSetupTest(unittest.TestCase):
     instance_setup.InstanceSetup.__init__(mock_setup)
     expected_calls = [
         # Setup and reading the configuration file.
-        mock.call.logger.Logger(name=mock.ANY, facility=mock.ANY),
+        mock.call.logger.Logger(
+            name=mock.ANY, console=False, facility=mock.ANY),
         mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
         mock.call.config.InstanceConfig(),
         # Setup for local SSD.
@@ -103,7 +104,8 @@ class InstanceSetupTest(unittest.TestCase):
 
     instance_setup.InstanceSetup.__init__(mock_setup)
     expected_calls = [
-        mock.call.logger.Logger(name=mock.ANY, facility=mock.ANY),
+        mock.call.logger.Logger(
+            name=mock.ANY, console=False, facility=mock.ANY),
         mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
         mock.call.config.InstanceConfig(),
         mock.call.config.InstanceConfig().GetOptionBool(

--- a/google_compute_engine/logger.py
+++ b/google_compute_engine/logger.py
@@ -19,11 +19,12 @@ import logging
 import logging.handlers
 
 
-def Logger(name, facility=None):
+def Logger(name, console=True, facility=None):
   """Get a logging object with handlers for sending logs to SysLog.
 
   Args:
     name: string, the name of the logger which will be added to log entries.
+    console: bool, True tocreate a handler for console logging.
     facility: int, an encoding of the SysLog handler's facility and priority.
 
   Returns:
@@ -34,11 +35,12 @@ def Logger(name, facility=None):
   logger.setLevel(logging.DEBUG)
   formatter = logging.Formatter(name + ': %(levelname)s %(message)s')
 
-  # Create a handler for console logging.
-  console_handler = logging.StreamHandler()
-  console_handler.setLevel(logging.DEBUG)
-  console_handler.setFormatter(formatter)
-  logger.addHandler(console_handler)
+  if console:
+    # Create a handler for console logging.
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.DEBUG)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
 
   if facility:
     # Create a handler for sending logs to SysLog.

--- a/google_compute_engine/metadata_scripts/script_manager.py
+++ b/google_compute_engine/metadata_scripts/script_manager.py
@@ -57,7 +57,7 @@ class ScriptManager(object):
     self.script_type = script_type
     name = '%s-script' % self.script_type
     facility = logging.handlers.SysLogHandler.LOG_DAEMON
-    self.logger = logger.Logger(name=name, facility=facility)
+    self.logger = logger.Logger(name=name, console=False, facility=facility)
     self.retriever = script_retriever.ScriptRetriever(self.logger, script_type)
     self.executor = script_executor.ScriptExecutor(self.logger, script_type)
     self._RunScripts()

--- a/google_compute_engine/metadata_scripts/tests/script_manager_test.py
+++ b/google_compute_engine/metadata_scripts/tests/script_manager_test.py
@@ -49,7 +49,8 @@ class ScriptManagerTest(unittest.TestCase):
 
     script_manager.ScriptManager(script_type)
     expected_calls = [
-        mock.call.logger.Logger(name=script_name, facility=mock.ANY),
+        mock.call.logger.Logger(
+            name=script_name, console=False, facility=mock.ANY),
         mock.call.retriever.ScriptRetriever(mock_logger_instance, script_type),
         mock.call.executor.ScriptExecutor(mock_logger_instance, script_type),
         mock.call.mkdir(prefix=script_prefix),

--- a/google_compute_engine/tests/logger_test.py
+++ b/google_compute_engine/tests/logger_test.py
@@ -37,14 +37,14 @@ class LoggerTest(unittest.TestCase):
     # Verify logger setup with a facility.
     address = '/dev/log'
     facility = 1
-    named_logger = logger.Logger(name=name, facility=facility)
+    named_logger = logger.Logger(name=name, console=True, facility=facility)
     mock_syslog.assert_called_once_with(address=address, facility=facility)
     mock_syslog.setLevel.assert_called_once_with(logger.logging.INFO)
     self.assertEqual(named_logger.handlers, [mock_stream, mock_syslog])
 
     # Verify the handlers are reset during repeated calls.
-    named_logger = logger.Logger(name=name)
-    self.assertEqual(named_logger.handlers, [mock_stream])
+    named_logger = logger.Logger(name=name, console=False)
+    self.assertEqual(named_logger.handlers, [])
 
 
 if __name__ == '__main__':

--- a/google_configs/rsyslog/90-google.conf
+++ b/google_configs/rsyslog/90-google.conf
@@ -1,0 +1,7 @@
+# Google Compute Engine default console logging.
+#
+# auth: logging from sshd.
+# daemon: logging from Google provided daemons.
+# kern: logging information in case of an unexpected crash during boot.
+#
+auth,daemon,kern.* /dev/console

--- a/package/systemd/postinst.sh
+++ b/package/systemd/postinst.sh
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Stop existing daemons
+# Stop existing daemons.
 systemctl stop --no-block google-accounts-daemon
 systemctl stop --no-block google-clock-skew-daemon
 systemctl stop --no-block google-ip-forwarding-daemon
 
-# Enable systemd services
-systemctl enable google-instance-setup.service
-systemctl enable google-startup-scripts.service
-systemctl enable google-shutdown-scripts.service
+# Enable systemd services.
 systemctl enable google-accounts-daemon.service
 systemctl enable google-clock-skew-daemon.service
+systemctl enable google-instance-setup.service
 systemctl enable google-ip-forwarding-daemon.service
+systemctl enable google-shutdown-scripts.service
+systemctl enable google-startup-scripts.service
 
-# Start daemons
+# Start daemons.
 systemctl start --no-block google-accounts-daemon
 systemctl start --no-block google-clock-skew-daemon
 systemctl start --no-block google-ip-forwarding-daemon

--- a/package/systemd/prerm.sh
+++ b/package/systemd/prerm.sh
@@ -18,10 +18,10 @@ if [ "$1" = purge ]; then
   systemctl stop --no-block google-clock-skew-daemon
   systemctl stop --no-block google-ip-forwarding-daemon
 
-  systemctl --no-reload disable google-instance-setup.service
-  systemctl --no-reload disable google-startup-scripts.service
-  systemctl --no-reload disable google-shutdown-scripts.service
   systemctl --no-reload disable google-accounts-daemon.service
   systemctl --no-reload disable google-clock-skew-daemon.service
+  systemctl --no-reload disable google-instance-setup.service
   systemctl --no-reload disable google-ip-forwarding-daemon.service
+  systemctl --no-reload disable google-shutdown-scripts.service
+  systemctl --no-reload disable google-startup-scripts.service
 fi

--- a/package/sysvinit/google-accounts-daemon
+++ b/package/sysvinit/google-accounts-daemon
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,112 +24,84 @@
 # Description:       Manages accounts from metadata SSH keys.
 ### END INIT INFO
 
-# Do NOT "set -e"
+# Do NOT "set -e".
 
-# PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="Google Compute Engine Accounts Daemon"
 NAME=google-accounts-daemon
 DAEMON=/usr/bin/google_accounts_daemon
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
-# Exit if the package is not installed
+# Exit if the package is not installed.
 [ -x "$DAEMON" ] || exit 0
 
-# Load the VERBOSE setting and other rcS variables
+# Load the rcS variables.
 . /lib/init/vars.sh
 
-# Define LSB log_* functions.
 # Depend on lsb-base (>= 3.2-14) to ensure that this file is present
 # and status_of_proc is working.
 . /lib/lsb/init-functions
 
 #
-# Function that starts the daemon/service
+# Function that starts the daemon/service.
 #
 do_start()
 {
-  # Return
-  #   0 if daemon has been started
-  #   1 if daemon was already running
-  #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
-    --test > /dev/null || return 1
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON \
-    || return 2
+  start-stop-daemon \
+    --background \
+    --exec $DAEMON \
+    --make-pidfile \
+    --pidfile $PIDFILE \
+    --quiet \
+    --start > /dev/null
 }
 
 #
-# Function that stops the daemon/service
+# Function that stops the daemon/service.
 #
 do_stop()
 {
-  # Return
-  #   0 if daemon has been stopped
-  #   1 if daemon was already stopped
-  #   2 if daemon could not be stopped
-  #   other if a failure occurred
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE \
-    --name $NAME
-  RETVAL="$?"
-  [ "$RETVAL" = 2 ] && return 2
+  start-stop-daemon \
+    --exec $DAEMON \
+    --pidfile $PIDFILE \
+    --quiet \
+    --retry=TERM/30/KILL/5 \
+    --stop > /dev/null
+
   # Wait for children to finish too if this is a daemon that forks
   # and if the daemon is only ever run from this initscript.
   # If the above conditions are not satisfied then add some other code
   # that waits for the process to drop all resources that could be
   # needed by services started subsequently.  A last resort is to
   # sleep for some time.
-  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
-  [ "$?" = 2 ] && return 2
-  # Many daemons don't delete their pidfiles when they exit.
+  start-stop-daemon \
+    --exec $DAEMON \
+    --oknodo \
+    --quiet \
+    --retry=0/30/KILL/5 \
+    --stop > /dev/null
+
+  # Delete the pidfile when the daemon exits.
   rm -f $PIDFILE
-  return "$RETVAL"
 }
 
 case "$1" in
   start)
-  [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
-  do_start
-  case "$?" in
-    0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-    2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-  esac
-  ;;
-  stop)
-  [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
-  do_stop
-  case "$?" in
-    0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-    2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-  esac
-  ;;
-  status)
-       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
-       ;;
-  restart|force-reload)
-  log_daemon_msg "Restarting $DESC" "$NAME"
-  do_stop
-  case "$?" in
-    0|1)
     do_start
-    case "$?" in
-      0) log_end_msg 0 ;;
-      1) log_end_msg 1 ;; # Old process is still running
-      *) log_end_msg 1 ;; # Failed to start
-    esac
     ;;
-    *)
-      # Failed to stop
-    log_end_msg 1
+  stop)
+    do_stop
     ;;
-  esac
-  ;;
+  status)
+    status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+    ;;
+  restart|force-reload)
+    do_stop
+    do_start
+    ;;
   *)
-  #echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
-  echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
-  exit 3
-  ;;
+    echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+    exit 1
+    ;;
 esac
 
 :

--- a/package/sysvinit/google-clock-skew-daemon
+++ b/package/sysvinit/google-clock-skew-daemon
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,111 +23,83 @@
 # Description:       Sync the system clock on migration.
 ### END INIT INFO
 
-# Do NOT "set -e"
+# Do NOT "set -e".
 
-# PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="Google Clock Skew Daemon"
 NAME=google-clock-skew-daemon
 DAEMON=/usr/bin/google_clock_skew_daemon
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
-# Exit if the package is not installed
+# Exit if the package is not installed.
 [ -x "$DAEMON" ] || exit 0
 
-# Load the VERBOSE setting and other rcS variables
+# Load the rcS variables.
 . /lib/init/vars.sh
 
-# Define LSB log_* functions.
 # Depend on lsb-base (>= 3.2-14) to ensure that this file is present
 # and status_of_proc is working.
 . /lib/lsb/init-functions
 
 #
-# Function that starts the daemon/service
+# Function that starts the daemon/service.
 #
 do_start()
 {
-  # Return
-  #   0 if daemon has been started
-  #   1 if daemon was already running
-  #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --make-pidfile --background \
-    --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
-    || return 1
-  start-stop-daemon --start --quiet --make-pidfile --background \
-    --pidfile $PIDFILE --exec $DAEMON || return 2
+  start-stop-daemon \
+    --background \
+    --exec $DAEMON \
+    --make-pidfile \
+    --pidfile $PIDFILE \
+    --quiet \
+    --start > /dev/null
 }
 
 #
-# Function that stops the daemon/service
+# Function that stops the daemon/service.
 #
 do_stop()
 {
-  # Return
-  #   0 if daemon has been stopped
-  #   1 if daemon was already stopped
-  #   2 if daemon could not be stopped
-  #   other if a failure occurred
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
-  RETVAL="$?"
-  [ "$RETVAL" = 2 ] && return 2
+  start-stop-daemon \
+    --exec $DAEMON \
+    --pidfile $PIDFILE \
+    --quiet \
+    --retry=TERM/30/KILL/5 \
+    --stop > /dev/null
+
   # Wait for children to finish too if this is a daemon that forks
   # and if the daemon is only ever run from this initscript.
   # If the above conditions are not satisfied then add some other code
   # that waits for the process to drop all resources that could be
   # needed by services started subsequently.  A last resort is to
   # sleep for some time.
-  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 \
-    --pidfile $PIDFILE
-  [ "$?" = 2 ] && return 2
-  # Many daemons don't delete their pidfiles when they exit.
+  start-stop-daemon \
+    --exec $DAEMON \
+    --oknodo \
+    --quiet \
+    --retry=0/30/KILL/5 \
+    --stop > /dev/null
+
+  # Delete the pidfile when the daemon exits.
   rm -f $PIDFILE
-  return "$RETVAL"
 }
 
 case "$1" in
   start)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
     do_start
-    case "$?" in
-      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-      2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
     ;;
   stop)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
     do_stop
-    case "$?" in
-      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-      2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
     ;;
   status)
-    status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
+    status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
     ;;
   restart|force-reload)
-    log_daemon_msg "Restarting $DESC" "$NAME"
     do_stop
-    case "$?" in
-      0|1)
-        do_start
-        case "$?" in
-          0) log_end_msg 0 ;;
-          1) log_end_msg 1 ;; # Old process is still running
-          *) log_end_msg 1 ;; # Failed to start
-        esac
-        ;;
-      *)
-        # Failed to stop
-        log_end_msg 1
-        ;;
-    esac
+    do_start
     ;;
   *)
     echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
-    exit 3
+    exit 1
     ;;
 esac
 

--- a/package/sysvinit/google-instance-setup
+++ b/package/sysvinit/google-instance-setup
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,39 +24,27 @@
 # Description:       Runs instance setup on boot.
 ### END INIT INFO
 
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="Google Compute Engine Instance Setup"
 NAME=google-instance-setup
 SCRIPTNAME=/etc/init.d/$NAME
 
-# Load the VERBOSE setting and other rcS variables
+# Load the rcS variables.
 . /lib/init/vars.sh
 
-# Define LSB log_* functions.
-# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
-# and status_of_proc is working.
-. /lib/lsb/init-functions
-
 #
-# Function that starts the daemon/service
+# Function that starts the daemon/service.
 #
 do_start()
 {
-  /usr/bin/google_instance_setup
+  /usr/bin/google_instance_setup > /dev/null
 }
 
 case "$1" in
   start)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
     do_start
-    case "$?" in
-      0) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-      *) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
     ;;
   *)
     echo "Usage: $SCRIPTNAME start" >&2
-    exit 3
+    exit 1
     ;;
 esac
 

--- a/package/sysvinit/google-ip-forwarding-daemon
+++ b/package/sysvinit/google-ip-forwarding-daemon
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,110 +23,83 @@
 # Description:       Manages IP forwarding.
 ### END INIT INFO
 
-# Do NOT "set -e"
+# Do NOT "set -e".
 
-# PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="Google IP Forwarding Daemon"
 NAME=google-ip-forwarding-daemon
 DAEMON=/usr/bin/google_ip_forwarding_daemon
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
-# Exit if the package is not installed
+# Exit if the package is not installed.
 [ -x "$DAEMON" ] || exit 0
 
-# Load the VERBOSE setting and other rcS variables
+# Load the rcS variables.
 . /lib/init/vars.sh
 
-# Define LSB log_* functions.
 # Depend on lsb-base (>= 3.2-14) to ensure that this file is present
 # and status_of_proc is working.
 . /lib/lsb/init-functions
 
 #
-# Function that starts the daemon/service
+# Function that starts the daemon/service.
 #
 do_start()
 {
-  # Return
-  #   0 if daemon has been started
-  #   1 if daemon was already running
-  #   2 if daemon could not be started
-  start-stop-daemon --start --quiet --make-pidfile --background \
-    --pidfile $PIDFILE --exec $DAEMON --test > /dev/null || return 1
-  start-stop-daemon --start --quiet --make-pidfile --background \
-    --pidfile $PIDFILE --exec $DAEMON || return 2
+  start-stop-daemon \
+    --background \
+    --exec $DAEMON \
+    --make-pidfile \
+    --pidfile $PIDFILE \
+    --quiet \
+    --start > /dev/null
 }
 
 #
-# Function that stops the daemon/service
+# Function that stops the daemon/service.
 #
 do_stop()
 {
-  # Return
-  #   0 if daemon has been stopped
-  #   1 if daemon was already stopped
-  #   2 if daemon could not be stopped
-  #   other if a failure occurred
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
-  RETVAL="$?"
-  [ "$RETVAL" = 2 ] && return 2
+  start-stop-daemon \
+    --exec $DAEMON \
+    --pidfile $PIDFILE \
+    --quiet \
+    --retry=TERM/30/KILL/5 \
+    --stop > /dev/null
+
   # Wait for children to finish too if this is a daemon that forks
   # and if the daemon is only ever run from this initscript.
   # If the above conditions are not satisfied then add some other code
   # that waits for the process to drop all resources that could be
   # needed by services started subsequently.  A last resort is to
   # sleep for some time.
-  start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 \
-    --pidfile $PIDFILE
-  [ "$?" = 2 ] && return 2
-  # Many daemons don't delete their pidfiles when they exit.
+  start-stop-daemon \
+    --exec $DAEMON \
+    --oknodo \
+    --quiet \
+    --retry=0/30/KILL/5 \
+    --stop > /dev/null
+
+  # Delete the pidfile when the daemon exits.
   rm -f $PIDFILE
-  return "$RETVAL"
 }
 
 case "$1" in
   start)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
     do_start
-    case "$?" in
-      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-      2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
     ;;
   stop)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
     do_stop
-    case "$?" in
-      0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-      2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
     ;;
   status)
-    status_of_proc -p "$PIDFILE" "$DAEMON" "$NAME" && exit 0 || exit $?
+    status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
     ;;
   restart|force-reload)
-    log_daemon_msg "Restarting $DESC" "$NAME"
     do_stop
-    case "$?" in
-      0|1)
-        do_start
-        case "$?" in
-          0) log_end_msg 0 ;;
-          1) log_end_msg 1 ;; # Old process is still running
-          *) log_end_msg 1 ;; # Failed to start
-        esac
-        ;;
-      *)
-        # Failed to stop
-        log_end_msg 1
-        ;;
-    esac
+    do_start
     ;;
   *)
     echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
-    exit 3
+    exit 1
     ;;
 esac
 

--- a/package/sysvinit/google-shutdown-scripts
+++ b/package/sysvinit/google-shutdown-scripts
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,46 +15,35 @@
 #
 ### BEGIN INIT INFO
 # Provides:          google_shutdown_scripts
-# Required-Start:    $local_fs $network $syslog
-# Required-Stop:
-# Default-Start:     0 6
-# Default-Stop:
+# Required-Start:
+# Required-Stop:     $remote_fs $syslog docker kubelet
+# Default-Start:
+# Default-Stop:      0 6
 # Short-Description: Google Compute Engine Shutdown Scripts
-# Description:       Runs a shutdown script from metadata.
+# Description:       Runs user specified shutdown scripts from metadata.
 ### END INIT INFO
 
-# Load the VERBOSE setting and other rcS variables
-. /lib/init/vars.sh
-
-# Define LSB log_* functions.
-# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
-# and status_of_proc is working.
-. /lib/lsb/init-functions
-
-DESC="Google Compute Engine Shutdown Scripts"
-NAME="google-shutdown-scripts"
+NAME=google-shutdown-scripts
 SCRIPTNAME=/etc/init.d/$NAME
 
+# Load the rcS variables.
+. /lib/init/vars.sh
+
 #
-# Function that starts the daemon/service
+# Function that stops the daemon/service.
 #
-do_start()
+do_stop()
 {
-  /usr/bin/google_metadata_script_runner --script-type shutdown
+  /usr/bin/google_metadata_script_runner --script-type shutdown > /dev/null
 }
 
 case "$1" in
-  start)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
-    do_start
-    case "$?" in
-      0) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-      *) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
+  stop)
+    do_stop
     ;;
   *)
-    echo "Usage: $SCRIPTNAME start" >&2
-    exit 3
+    echo "Usage: $SCRIPTNAME stop" >&2
+    exit 1
     ;;
 esac
 

--- a/package/sysvinit/google-startup-scripts
+++ b/package/sysvinit/google-startup-scripts
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,46 +15,35 @@
 #
 ### BEGIN INIT INFO
 # Provides:          google_startup_scripts
-# Required-Start:    $google_instance_setup
+# Required-Start:    $all $google_instance_setup
 # Required-Stop:
 # Default-Start:     2 3 4 5
 # Default-Stop:
 # Short-Description: Google Compute Engine Startup Scripts
-# Description:       Runs a startup script from metadata.
+# Description:       Runs user specified startup scripts from metadata.
 ### END INIT INFO
 
-# Load the VERBOSE setting and other rcS variables
-. /lib/init/vars.sh
-
-# Define LSB log_* functions.
-# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
-# and status_of_proc is working.
-. /lib/lsb/init-functions
-
-DESC="Google Compute Engine Startup Scripts"
-NAME="google-startup-scripts"
+NAME=google-startup-scripts
 SCRIPTNAME=/etc/init.d/$NAME
 
+# Load the rcS variables.
+. /lib/init/vars.sh
+
 #
-# Function that starts the daemon/service
+# Function that starts the daemon/service.
 #
 do_start()
 {
-  /usr/bin/google_metadata_script_runner --script-type startup
+  /usr/bin/google_metadata_script_runner --script-type startup > /dev/null
 }
 
 case "$1" in
   start)
-    [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
     do_start
-    case "$?" in
-      0) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-      *) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-    esac
     ;;
   *)
     echo "Usage: $SCRIPTNAME start" >&2
-    exit 3
+    exit 1
     ;;
 esac
 

--- a/package/sysvinit/postinst.sh
+++ b/package/sysvinit/postinst.sh
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-update-rc.d google-instance-setup defaults
-update-rc.d google-startup-scripts defaults
-update-rc.d google-shutdown-scripts defaults
 update-rc.d google-accounts-daemon defaults
 update-rc.d google-clock-skew-daemon defaults
+update-rc.d google-instance-setup defaults
 update-rc.d google-ip-forwarding-daemon defaults
+update-rc.d google-shutdown-scripts defaults
+update-rc.d google-startup-scripts defaults

--- a/package/sysvinit/prerm.sh
+++ b/package/sysvinit/prerm.sh
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 if [ "$1" = purge ]; then
-  update-rc.d google-instance-setup remove
-  update-rc.d google-startup-scripts remove
-  update-rc.d google-shutdown-scripts remove
   update-rc.d google-accounts-daemon remove
   update-rc.d google-clock-skew-daemon remove
+  update-rc.d google-instance-setup remove
   update-rc.d google-ip-forwarding-daemon remove
+  update-rc.d google-shutdown-scripts defaults
+  update-rc.d google-startup-scripts defaults
 fi


### PR DESCRIPTION
- Shutdown scripts should execute on VM shutdown.
- Logging is handled by daemons instead of the sysvinit configs.
- Logger module optionally does not write to the console.
- Config file for writing logs to serial port output.