### PR TITLE
Fix logging and a bug in instance config.

### DIFF
--- a/google_compute_engine/accounts/tests/accounts_daemon_test.py
+++ b/google_compute_engine/accounts/tests/accounts_daemon_test.py
@@ -49,9 +49,9 @@ class AccountsDaemonTest(unittest.TestCase):
     mocks.attach_mock(mock_utils, 'utils')
     with mock.patch.object(
         accounts_daemon.AccountsDaemon, 'HandleAccounts') as mock_handle:
-      accounts_daemon.AccountsDaemon(groups='foo,bar', remove=True)
+      accounts_daemon.AccountsDaemon(groups='foo,bar', remove=True, debug=True)
       expected_calls = [
-          mock.call.logger.Logger(name=mock.ANY, facility=mock.ANY),
+          mock.call.logger.Logger(name=mock.ANY, debug=True, facility=mock.ANY),
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.AccountsUtils(
               logger=mock_logger_instance, groups='foo,bar', remove=True),
@@ -81,7 +81,8 @@ class AccountsDaemonTest(unittest.TestCase):
     with mock.patch.object(accounts_daemon.AccountsDaemon, 'HandleAccounts'):
       accounts_daemon.AccountsDaemon()
       expected_calls = [
-          mock.call.logger.Logger(name=mock.ANY, facility=mock.ANY),
+          mock.call.logger.Logger(
+              name=mock.ANY, debug=False, facility=mock.ANY),
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.AccountsUtils(
               logger=mock_logger_instance, groups=None, remove=False),

--- a/google_compute_engine/clock_skew/tests/clock_skew_daemon_test.py
+++ b/google_compute_engine/clock_skew/tests/clock_skew_daemon_test.py
@@ -39,7 +39,7 @@ class ClockSkewDaemonTest(unittest.TestCase):
         clock_skew_daemon.ClockSkewDaemon, 'HandleClockSync') as mock_handle:
       clock_skew_daemon.ClockSkewDaemon()
       expected_calls = [
-          mock.call.logger(name=mock.ANY, facility=mock.ANY),
+          mock.call.logger(name=mock.ANY, debug=False, facility=mock.ANY),
           mock.call.watcher.MetadataWatcher(logger=mock_logger),
           mock.call.lock(clock_skew_daemon.LOCKFILE),
           mock.call.lock().__enter__(),
@@ -62,9 +62,9 @@ class ClockSkewDaemonTest(unittest.TestCase):
     mock_logger.return_value = mock_logger
     with mock.patch.object(
         clock_skew_daemon.ClockSkewDaemon, 'HandleClockSync'):
-      clock_skew_daemon.ClockSkewDaemon()
+      clock_skew_daemon.ClockSkewDaemon(debug=True)
       expected_calls = [
-          mock.call.logger(name=mock.ANY, facility=mock.ANY),
+          mock.call.logger(name=mock.ANY, debug=True, facility=mock.ANY),
           mock.call.watcher.MetadataWatcher(logger=mock_logger),
           mock.call.lock(clock_skew_daemon.LOCKFILE),
           mock.call.logger.warning('Test Error'),

--- a/google_compute_engine/instance_setup/instance_config.py
+++ b/google_compute_engine/instance_setup/instance_config.py
@@ -24,6 +24,7 @@ instance_config.cfg can be removed prior to image packaging.
 import os
 
 from google_compute_engine import config_manager
+from google_compute_engine.compat import parser
 
 
 class InstanceConfig(config_manager.ConfigManager):
@@ -77,7 +78,15 @@ class InstanceConfig(config_manager.ConfigManager):
     super(InstanceConfig, self).__init__(
         config_file=self.instance_config_template,
         config_header=self.instance_config_header)
-    for section, options in sorted(self.instance_config_options.items()):
+
+    if os.path.exists(self.instance_config):
+      config = parser.SafeConfigParser()
+      config.read(self.instance_config)
+      defaults = dict((s, dict(config.items(s))) for s in config.sections())
+    else:
+      defaults = self.instance_config_options
+
+    for section, options in sorted(defaults.items()):
       for option, value in sorted(options.items()):
         super(InstanceConfig, self).SetOption(
             section, option, value, overwrite=False)

--- a/google_compute_engine/instance_setup/instance_setup.py
+++ b/google_compute_engine/instance_setup/instance_setup.py
@@ -34,8 +34,6 @@ from google_compute_engine.instance_setup import instance_config
 class InstanceSetup(object):
   """Initialize the instance the first time it boots."""
 
-  config_file = '/etc/default/instance_configs.cfg'
-
   def __init__(self, debug=False):
     """Constructor.
 

--- a/google_compute_engine/instance_setup/instance_setup.py
+++ b/google_compute_engine/instance_setup/instance_setup.py
@@ -16,6 +16,7 @@
 """Run initialization code the first time the instance boots."""
 
 import logging.handlers
+import optparse
 import os
 import re
 import shutil
@@ -35,10 +36,15 @@ class InstanceSetup(object):
 
   config_file = '/etc/default/instance_configs.cfg'
 
-  def __init__(self):
+  def __init__(self, debug=False):
+    """Constructor.
+
+    Args:
+      debug: bool, True if debug output should write to the console.
+    """
     facility = logging.handlers.SysLogHandler.LOG_DAEMON
     self.logger = logger.Logger(
-        name='instance-setup', console=False, facility=facility)
+        name='instance-setup', debug=debug, facility=facility)
     self.watcher = metadata_watcher.MetadataWatcher(logger=self.logger)
     self.metadata_dict = None
     self.instance_config = instance_config.InstanceConfig()
@@ -171,7 +177,11 @@ class InstanceSetup(object):
 
 
 def main():
-  InstanceSetup()
+  parser = optparse.OptionParser()
+  parser.add_option('-d', '--debug', action='store_true', dest='debug',
+                    help='print debug output to the console.')
+  (options, _) = parser.parse_args()
+  InstanceSetup(debug=bool(options.debug))
 
 
 if __name__ == '__main__':

--- a/google_compute_engine/instance_setup/tests/instance_config_test.py
+++ b/google_compute_engine/instance_setup/tests/instance_config_test.py
@@ -41,22 +41,57 @@ class InstanceConfigTest(unittest.TestCase):
         },
     }
 
+  @mock.patch('google_compute_engine.instance_setup.instance_config.os.path.exists')
   @mock.patch('google_compute_engine.instance_setup.instance_config.config_manager.ConfigManager.SetOption')
   @mock.patch('google_compute_engine.instance_setup.instance_config.config_manager.ConfigManager.__init__')
-  def testInstanceConfig(self, mock_init, mock_set):
+  def testInstanceConfig(self, mock_init, mock_set, mock_exists):
     mocks = mock.Mock()
     mocks.attach_mock(mock_init, 'init')
     mocks.attach_mock(mock_set, 'set')
+    mocks.attach_mock(mock_exists, 'exists')
+    mock_exists.return_value = False
 
     instance_config.InstanceConfig()
     expected_calls = [
         mock.call.init(
             config_file='template', config_header='/tmp/test.py template'),
+        mock.call.exists('config'),
         mock.call.set('first', 'a', 'false', overwrite=False),
         mock.call.set('second', 'b', 'true', overwrite=False),
         mock.call.set('third', 'c', '1', overwrite=False),
         mock.call.set('third', 'd', '2', overwrite=False),
         mock.call.set('third', 'e', '3', overwrite=False),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  @mock.patch('google_compute_engine.instance_setup.instance_config.os.path.exists')
+  @mock.patch('google_compute_engine.instance_setup.instance_config.parser')
+  @mock.patch('google_compute_engine.instance_setup.instance_config.config_manager.ConfigManager.SetOption')
+  @mock.patch('google_compute_engine.instance_setup.instance_config.config_manager.ConfigManager.__init__')
+  def testInstanceConfigExists(self, mock_init, mock_set, mock_parser, mock_exists):
+    mock_config = mock.create_autospec(instance_config.parser.SafeConfigParser)
+    mock_config.read = mock.Mock()
+    mock_config.sections = mock.Mock()
+    mock_config.sections.return_value = ['a', 'b']
+    mock_config.items = lambda key: {'key: %s' % key: 'value: %s' % key}
+    mock_parser.SafeConfigParser.return_value = mock_config
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_init, 'init')
+    mocks.attach_mock(mock_set, 'set')
+    mocks.attach_mock(mock_parser, 'parser')
+    mocks.attach_mock(mock_exists, 'exists')
+    mock_exists.return_value = True
+
+    instance_config.InstanceConfig()
+    expected_calls = [
+        mock.call.init(
+            config_file='template', config_header='/tmp/test.py template'),
+        mock.call.exists('config'),
+        mock.call.parser.SafeConfigParser(),
+        mock.call.parser.SafeConfigParser().read('config'),
+        mock.call.parser.SafeConfigParser().sections(),
+        mock.call.set('a', 'key: a', 'value: a', overwrite=False),
+        mock.call.set('b', 'key: b', 'value: b', overwrite=False),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 

--- a/google_compute_engine/instance_setup/tests/instance_setup_test.py
+++ b/google_compute_engine/instance_setup/tests/instance_setup_test.py
@@ -54,7 +54,7 @@ class InstanceSetupTest(unittest.TestCase):
     expected_calls = [
         # Setup and reading the configuration file.
         mock.call.logger.Logger(
-            name=mock.ANY, console=False, facility=mock.ANY),
+            name=mock.ANY, debug=False, facility=mock.ANY),
         mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
         mock.call.config.InstanceConfig(),
         # Setup for local SSD.
@@ -105,7 +105,7 @@ class InstanceSetupTest(unittest.TestCase):
     instance_setup.InstanceSetup.__init__(mock_setup)
     expected_calls = [
         mock.call.logger.Logger(
-            name=mock.ANY, console=False, facility=mock.ANY),
+            name=mock.ANY, debug=False, facility=mock.ANY),
         mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
         mock.call.config.InstanceConfig(),
         mock.call.config.InstanceConfig().GetOptionBool(

--- a/google_compute_engine/ip_forwarding/tests/ip_forwarding_daemon_test.py
+++ b/google_compute_engine/ip_forwarding/tests/ip_forwarding_daemon_test.py
@@ -50,9 +50,9 @@ class IpForwardingDaemonTest(unittest.TestCase):
     with mock.patch.object(
         ip_forwarding_daemon.IpForwardingDaemon,
         'HandleForwardedIps') as mock_handle:
-      ip_forwarding_daemon.IpForwardingDaemon(proto_id='66')
+      ip_forwarding_daemon.IpForwardingDaemon(proto_id='66', debug=True)
       expected_calls = [
-          mock.call.logger.Logger(name=mock.ANY, facility=mock.ANY),
+          mock.call.logger.Logger(name=mock.ANY, debug=True, facility=mock.ANY),
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.IpForwardingUtils(
               logger=mock_logger_instance, proto_id='66'),
@@ -83,7 +83,8 @@ class IpForwardingDaemonTest(unittest.TestCase):
         ip_forwarding_daemon.IpForwardingDaemon, 'HandleForwardedIps'):
       ip_forwarding_daemon.IpForwardingDaemon()
       expected_calls = [
-          mock.call.logger.Logger(name=mock.ANY, facility=mock.ANY),
+          mock.call.logger.Logger(
+              name=mock.ANY, debug=False, facility=mock.ANY),
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.IpForwardingUtils(
               logger=mock_logger_instance, proto_id=None),

--- a/google_compute_engine/logger.py
+++ b/google_compute_engine/logger.py
@@ -19,12 +19,12 @@ import logging
 import logging.handlers
 
 
-def Logger(name, console=True, facility=None):
+def Logger(name, debug=False, facility=None):
   """Get a logging object with handlers for sending logs to SysLog.
 
   Args:
     name: string, the name of the logger which will be added to log entries.
-    console: bool, True tocreate a handler for console logging.
+    debug: bool, True if debug output should write to the console.
     facility: int, an encoding of the SysLog handler's facility and priority.
 
   Returns:
@@ -32,10 +32,11 @@ def Logger(name, console=True, facility=None):
   """
   logger = logging.getLogger(name)
   logger.handlers = []
+  logger.propagate = False
   logger.setLevel(logging.DEBUG)
   formatter = logging.Formatter(name + ': %(levelname)s %(message)s')
 
-  if console:
+  if debug:
     # Create a handler for console logging.
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.DEBUG)

--- a/google_compute_engine/metadata_scripts/script_manager.py
+++ b/google_compute_engine/metadata_scripts/script_manager.py
@@ -48,16 +48,17 @@ def _CreateTempDir(prefix):
 class ScriptManager(object):
   """A class for retrieving and executing metadata scripts."""
 
-  def __init__(self, script_type):
+  def __init__(self, script_type, debug=False):
     """Constructor.
 
     Args:
       script_type: string, the metadata script type to run.
+      debug: bool, True if debug output should write to the console.
     """
     self.script_type = script_type
     name = '%s-script' % self.script_type
     facility = logging.handlers.SysLogHandler.LOG_DAEMON
-    self.logger = logger.Logger(name=name, console=False, facility=facility)
+    self.logger = logger.Logger(name=name, debug=debug, facility=facility)
     self.retriever = script_retriever.ScriptRetriever(self.logger, script_type)
     self.executor = script_executor.ScriptExecutor(self.logger, script_type)
     self._RunScripts()
@@ -75,6 +76,8 @@ class ScriptManager(object):
 def main():
   script_types = ('startup', 'shutdown')
   parser = optparse.OptionParser()
+  parser.add_option('-d', '--debug', action='store_true', dest='debug',
+                    help='print debug output to the console.')
   parser.add_option('--script-type', dest='script_type',
                     help='metadata script type.')
   (options, _) = parser.parse_args()
@@ -87,7 +90,7 @@ def main():
 
   instance_config = config_manager.ConfigManager()
   if instance_config.GetOptionBool('MetadataScripts', script_type):
-    ScriptManager(script_type)
+    ScriptManager(script_type, debug=bool(options.debug))
 
 
 if __name__ == '__main__':

--- a/google_compute_engine/metadata_scripts/tests/script_manager_test.py
+++ b/google_compute_engine/metadata_scripts/tests/script_manager_test.py
@@ -50,7 +50,7 @@ class ScriptManagerTest(unittest.TestCase):
     script_manager.ScriptManager(script_type)
     expected_calls = [
         mock.call.logger.Logger(
-            name=script_name, console=False, facility=mock.ANY),
+            name=script_name, debug=False, facility=mock.ANY),
         mock.call.retriever.ScriptRetriever(mock_logger_instance, script_type),
         mock.call.executor.ScriptExecutor(mock_logger_instance, script_type),
         mock.call.mkdir(prefix=script_prefix),

--- a/google_compute_engine/tests/logger_test.py
+++ b/google_compute_engine/tests/logger_test.py
@@ -30,20 +30,20 @@ class LoggerTest(unittest.TestCase):
     name = 'test'
 
     # Verify basic logger setup.
-    named_logger = logger.Logger(name=name)
+    named_logger = logger.Logger(name=name, debug=True)
     mock_stream.setLevel.assert_called_once_with(logger.logging.DEBUG)
     self.assertEqual(named_logger.handlers, [mock_stream])
 
     # Verify logger setup with a facility.
     address = '/dev/log'
     facility = 1
-    named_logger = logger.Logger(name=name, console=True, facility=facility)
+    named_logger = logger.Logger(name=name, debug=True, facility=facility)
     mock_syslog.assert_called_once_with(address=address, facility=facility)
     mock_syslog.setLevel.assert_called_once_with(logger.logging.INFO)
     self.assertEqual(named_logger.handlers, [mock_stream, mock_syslog])
 
     # Verify the handlers are reset during repeated calls.
-    named_logger = logger.Logger(name=name, console=False)
+    named_logger = logger.Logger(name=name, debug=False)
     self.assertEqual(named_logger.handlers, [])
 
 


### PR DESCRIPTION
- The instance config should reuse the instance config file if it exists.
- The logger should not propagate message to the system logger.
- Remove duplicate logging to console from a running daemon.
- Add a debug mode for executing scripts and daemons.

More debug logging can be added as appropriate.