### PR TITLE
Add a default config file for partner defaults.

### DIFF
--- a/package/instance_configs.cfg
+++ b/package/instance_configs.cfg
@@ -1,0 +1,22 @@
+[Accounts]
+deprovision_remove = false
+groups = adm,dip,lxd,plugdev,video
+
+[Daemons]
+accounts_daemon = true
+clock_skew_daemon = true
+ip_forwarding_daemon = true
+
+[InstanceSetup]
+network_enabled = true
+optimize_local_ssd = true
+set_boto_config = true
+set_host_keys = true
+set_multiqueue = true
+
+[IpForwarding]
+ethernet_proto_id = 66
+
+[MetadataScripts]
+shutdown = true
+startup = true

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,13 @@ def GetInitFiles(path):
   return list(set(glob.glob(valid)) - set(glob.glob(invalid)))
 
 
+# Common data files to add as part of all Linux distributions.
+data_files = [
+    ('/etc/default', ['package/instance_configs.cfg']),
+]
+
+
+# Data files specific to the various Linux init systems.
 data_files_dict = {
     'systemd': [('/usr/lib/systemd/system', GetInitFiles('package/systemd'))],
     'sysvinit': [('/etc/init.d', GetInitFiles('package/sysvinit'))],
@@ -51,7 +58,7 @@ if os.environ.get('CONFIG') not in data_files_dict.keys():
 setuptools.setup(
     author='Google Compute Engine Team',
     author_email='gc-team@google.com',
-    data_files=data_files_dict.get(os.environ['CONFIG']),
+    data_files=data_files + data_files_dict.get(os.environ['CONFIG']),
     description='Google Compute Engine',
     include_package_data=True,
     install_requires=['boto'],


### PR DESCRIPTION
This enables a partner to provide their own default values without
overriding user settings during package upgrades.