### PR TITLE
Keep SysLog running in systemd during shutdown.

### DIFF
--- a/package/systemd/google-shutdown-scripts.service
+++ b/package/systemd/google-shutdown-scripts.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Google Compute Engine Shutdown Scripts
-After=local-fs.target network-online.target network.target google-instance-setup.service
+After=local-fs.target network-online.target network.target rsyslog.service
+After=google-instance-setup.service
 Wants=local-fs.target network-online.target network.target
 
 [Service]

--- a/package/systemd/google-startup-scripts.service
+++ b/package/systemd/google-startup-scripts.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Google Compute Engine Startup Scripts
-After=local-fs.target network-online.target network.target google-instance-setup.service
+After=local-fs.target network-online.target network.target rsyslog.service
+After=google-instance-setup.service
 Wants=local-fs.target network-online.target network.target
 
 [Service]


### PR DESCRIPTION
Shutdown scripts log output to SysLog.