### PR TITLE
[build] support ubuntu 14.04

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -55,3 +55,6 @@ build_distro 'el7' 'rpm' 'systemd' '/usr/lib/python2.7/site-packages'
 # Debian
 build_distro 'wheezy' 'deb' 'sysvinit' '/usr/lib/python2.7/dist-packages'
 build_distro 'jessie' 'deb' 'systemd' '/usr/lib/python2.7/dist-packages'
+
+# Ubuntu
+build_distro 'ubuntu-14.04' 'deb' 'upstart' '/usr/lib/python2.7/dist-packages'

--- a/google_configs/build_packages.sh
+++ b/google_configs/build_packages.sh
@@ -42,23 +42,24 @@ function build_distro() {
     --url 'https://github.com/GoogleCloudPlatform/compute-image-packages' \
     --vendor 'Google Compute Engine Team' \
     --version '2.0.0' \
+    --replaces 'gce-startup-scripts' \
     "${COMMON_FILES[@]}" \
     "${files[@]:2}"
 }
 
-# RHEL/CentOS 6
+# RHEL/CentOS
 build_distro 'el6' 'rpm' \
   'bin/set_hostname=/etc/dhcp/dhclient-exit-hooks'
-
-# RHEL/CentOS 7
 build_distro 'el7' 'rpm' \
   'bin/set_hostname=/usr/bin/set_hostname' \
   'dhcp/google_hostname.sh=/etc/dhcp/dhclient.d/google_hostname.sh'
 
-# Debian 7
+# Debian
 build_distro 'wheezy' 'deb' \
   'bin/set_hostname=/etc/dhcp/dhclient-exit-hooks.d/set_hostname'
-
-# Debian 8
 build_distro 'jessie' 'deb' \
+  'bin/set_hostname=/etc/dhcp/dhclient-exit-hooks.d/set_hostname'
+
+# Ubuntu
+build_distro 'ubuntu-14.04' 'deb' \
   'bin/set_hostname=/etc/dhcp/dhclient-exit-hooks.d/set_hostname'


### PR DESCRIPTION
Note that the google-config package conflicts with the  files gcp-startup used to provide, specially 90-google.conf and 11-gce-network-security.conf. This is assuming the gcp-startup package is being deprecated in favor of splitting out the startup sripts and configs (btw big +1).

It would be great to have these packages uploaded to the cloud package repo.