### PR TITLE
Update exception handling in the metadata watcher.

### DIFF
--- a/google_compute_engine/instance_setup/instance_setup.py
+++ b/google_compute_engine/instance_setup/instance_setup.py
@@ -53,8 +53,7 @@ class InstanceSetup(object):
     if self.instance_config.GetOptionBool('InstanceSetup', 'set_multiqueue'):
       self._RunScript('set_multiqueue')
     if self.instance_config.GetOptionBool('InstanceSetup', 'network_enabled'):
-      while not self.metadata_dict:
-        self.metadata_dict = self.watcher.GetMetadata()
+      self.metadata_dict = self.watcher.GetMetadata()
       if self.instance_config.GetOptionBool('InstanceSetup', 'set_host_keys'):
         self._SetSshHostKeys()
       if self.instance_config.GetOptionBool('InstanceSetup', 'set_boto_config'):

--- a/google_compute_engine/instance_setup/tests/instance_setup_test.py
+++ b/google_compute_engine/instance_setup/tests/instance_setup_test.py
@@ -44,7 +44,7 @@ class InstanceSetupTest(unittest.TestCase):
     mock_logger_instance = mock.Mock()
     mock_logger.Logger.return_value = mock_logger_instance
     mock_watcher_instance = mock.Mock()
-    mock_watcher_instance.GetMetadata.side_effect = [{}, {'hello': 'world'}]
+    mock_watcher_instance.GetMetadata.return_value = {'hello': 'world'}
     mock_watcher.MetadataWatcher.return_value = mock_watcher_instance
     mock_config_instance = mock.Mock()
     mock_config_instance.GetOptionBool.return_value = True
@@ -68,8 +68,6 @@ class InstanceSetupTest(unittest.TestCase):
         # Check network access for reaching the metadata server.
         mock.call.config.InstanceConfig().GetOptionBool(
             'InstanceSetup', 'network_enabled'),
-        # Retry metadata requests until network is available.
-        mock.call.watcher.MetadataWatcher().GetMetadata(),
         mock.call.watcher.MetadataWatcher().GetMetadata(),
         # Setup for SSH host keys if necessary.
         mock.call.config.InstanceConfig().GetOptionBool(

--- a/google_compute_engine/metadata_watcher.py
+++ b/google_compute_engine/metadata_watcher.py
@@ -140,6 +140,30 @@ class MetadataWatcher(object):
         break
     return json.loads(response.read().decode('utf-8'))
 
+  def _HandleMetadataUpdate(self, metadata_key='', recursive=True, wait=True):
+    """Wait for a successful metadata response.
+
+    Args:
+      metadata_key: string, the metadata key to watch for changes.
+      recursive: bool, True if we should recursively watch for metadata changes.
+      wait: bool, True if we should wait for a metadata change.
+
+    Returns:
+      json, the deserialized contents of the metadata server.
+    """
+    exception = None
+    while True:
+      try:
+        return self._GetMetadataUpdate(
+            metadata_key=metadata_key, recursive=recursive, wait=wait)
+      except (httpclient.HTTPException, socket.error, urlerror.URLError) as e:
+        if isinstance(e, type(exception)) and e.args == exception.args:
+          continue
+        else:
+          exception = e
+          message = 'GET request error retrieving metadata. %s.'
+          self.logger.error(message, str(exception))
+
   def WatchMetadata(self, handler, metadata_key='', recursive=True):
     """Watch for changes to the contents of the metadata server.
 
@@ -149,11 +173,8 @@ class MetadataWatcher(object):
       recursive: bool, True if we should recursively watch for metadata changes.
     """
     while True:
-      try:
-        response = self._GetMetadataUpdate(
-            metadata_key=metadata_key, recursive=recursive, wait=True)
-      except (httpclient.HTTPException, socket.error, urlerror.URLError) as e:
-        self.logger.error('GET request error watching metadata. %s.', str(e))
+      response = self._HandleMetadataUpdate(
+          metadata_key=metadata_key, recursive=recursive, wait=True)
       try:
         handler(response)
       except Exception as e:
@@ -169,9 +190,5 @@ class MetadataWatcher(object):
     Returns:
       json, the deserialized contents of the metadata server or None if error.
     """
-    try:
-      return self._GetMetadataUpdate(
-          metadata_key=metadata_key, recursive=recursive, wait=False)
-    except (httpclient.HTTPException, socket.error, urlerror.URLError) as e:
-      self.logger.error('GET request error retrieving metadata. %s.', str(e))
-    return None
+    return self._HandleMetadataUpdate(
+        metadata_key=metadata_key, recursive=recursive, wait=False)

--- a/google_compute_engine/metadata_watcher.py
+++ b/google_compute_engine/metadata_watcher.py
@@ -162,7 +162,7 @@ class MetadataWatcher(object):
         else:
           exception = e
           message = 'GET request error retrieving metadata. %s.'
-          self.logger.error(message, str(exception))
+          self.logger.exception(message, exception)
 
   def WatchMetadata(self, handler, metadata_key='', recursive=True):
     """Watch for changes to the contents of the metadata server.
@@ -178,7 +178,7 @@ class MetadataWatcher(object):
       try:
         handler(response)
       except Exception as e:
-        self.logger.error('Exception calling the response handler. %s.', str(e))
+        self.logger.exception('Exception calling the response handler. %s.', e)
 
   def GetMetadata(self, metadata_key='', recursive=True):
     """Retrieve the contents of metadata server for a metadata key.

--- a/google_compute_engine/tests/metadata_watcher_test.py
+++ b/google_compute_engine/tests/metadata_watcher_test.py
@@ -202,7 +202,7 @@ class MetadataWatcherTest(unittest.TestCase):
     self.assertEqual(self.mock_watcher.GetMetadata(), {})
     mock_response.assert_called_once_with(
         metadata_key='', recursive=True, wait=False)
-    self.mock_watcher.logger.error.assert_not_called()
+    self.mock_watcher.logger.exception.assert_not_called()
 
   def testHandleMetadataUpdateException(self):
     mock_response = mock.Mock()
@@ -224,9 +224,9 @@ class MetadataWatcherTest(unittest.TestCase):
     ] * 5
     self.assertEqual(mock_response.mock_calls, expected_calls)
     expected_calls = [
-        mock.call.error(mock.ANY, str(first)),
-        mock.call.error(mock.ANY, str(second)),
-        mock.call.error(mock.ANY, str(third)),
+        mock.call.exception(mock.ANY, first),
+        mock.call.exception(mock.ANY, second),
+        mock.call.exception(mock.ANY, third),
     ]
     self.assertEqual(self.mock_logger.mock_calls, expected_calls)
 
@@ -236,7 +236,7 @@ class MetadataWatcherTest(unittest.TestCase):
     self.mock_watcher._HandleMetadataUpdate = mock_response
     mock_handler = mock.Mock()
     mock_handler.side_effect = Exception()
-    self.mock_logger.error.side_effect = RuntimeError()
+    self.mock_logger.exception.side_effect = RuntimeError()
     recursive = True
 
     with self.assertRaises(RuntimeError):
@@ -249,7 +249,7 @@ class MetadataWatcherTest(unittest.TestCase):
     mock_response = mock.Mock()
     mock_response.side_effect = metadata_watcher.socket.timeout()
     self.mock_watcher._GetMetadataUpdate = mock_response
-    self.mock_logger.error.side_effect = RuntimeError()
+    self.mock_logger.exception.side_effect = RuntimeError()
     metadata_key = 'instance/id'
     recursive = False
 
@@ -267,7 +267,7 @@ class MetadataWatcherTest(unittest.TestCase):
     self.assertEqual(self.mock_watcher.GetMetadata(), {})
     mock_response.assert_called_once_with(
         metadata_key='', recursive=True, wait=False)
-    self.mock_watcher.logger.error.assert_not_called()
+    self.mock_watcher.logger.exception.assert_not_called()
 
   def testGetMetadataArgs(self):
     mock_response = mock.Mock()
@@ -281,7 +281,7 @@ class MetadataWatcherTest(unittest.TestCase):
     self.assertEqual(response, {})
     mock_response.assert_called_once_with(
         metadata_key=metadata_key, recursive=False, wait=False)
-    self.mock_watcher.logger.error.assert_not_called()
+    self.mock_watcher.logger.exception.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/google_compute_engine/tests/metadata_watcher_test.py
+++ b/google_compute_engine/tests/metadata_watcher_test.py
@@ -194,10 +194,46 @@ class MetadataWatcherTest(unittest.TestCase):
     expected_calls = [mock.call(request_url, params=self.params)] * 3
     self.assertEqual(mock_response.mock_calls, expected_calls)
 
-  def testWatchMetadata(self):
+  def testHandleMetadataUpdate(self):
     mock_response = mock.Mock()
     mock_response.return_value = {}
     self.mock_watcher._GetMetadataUpdate = mock_response
+
+    self.assertEqual(self.mock_watcher.GetMetadata(), {})
+    mock_response.assert_called_once_with(
+        metadata_key='', recursive=True, wait=False)
+    self.mock_watcher.logger.error.assert_not_called()
+
+  def testHandleMetadataUpdateException(self):
+    mock_response = mock.Mock()
+    first = metadata_watcher.socket.timeout()
+    second = metadata_watcher.socket.timeout('a')
+    third = metadata_watcher.urlerror.URLError('b')
+    mock_response.side_effect = [first, second, second, third, {}]
+    self.mock_watcher._GetMetadataUpdate = mock_response
+    metadata_key = 'instance/id'
+    recursive = False
+    wait = False
+
+    self.assertEqual(
+        self.mock_watcher._HandleMetadataUpdate(
+            metadata_key=metadata_key, recursive=recursive, wait=wait),
+        {})
+    expected_calls = [
+        mock.call(metadata_key=metadata_key, recursive=recursive, wait=wait),
+    ] * 5
+    self.assertEqual(mock_response.mock_calls, expected_calls)
+    expected_calls = [
+        mock.call.error(mock.ANY, str(first)),
+        mock.call.error(mock.ANY, str(second)),
+        mock.call.error(mock.ANY, str(third)),
+    ]
+    self.assertEqual(self.mock_logger.mock_calls, expected_calls)
+
+  def testWatchMetadata(self):
+    mock_response = mock.Mock()
+    mock_response.return_value = {}
+    self.mock_watcher._HandleMetadataUpdate = mock_response
     mock_handler = mock.Mock()
     mock_handler.side_effect = Exception()
     self.mock_logger.error.side_effect = RuntimeError()
@@ -226,7 +262,7 @@ class MetadataWatcherTest(unittest.TestCase):
   def testGetMetadata(self):
     mock_response = mock.Mock()
     mock_response.return_value = {}
-    self.mock_watcher._GetMetadataUpdate = mock_response
+    self.mock_watcher._HandleMetadataUpdate = mock_response
 
     self.assertEqual(self.mock_watcher.GetMetadata(), {})
     mock_response.assert_called_once_with(
@@ -236,7 +272,7 @@ class MetadataWatcherTest(unittest.TestCase):
   def testGetMetadataArgs(self):
     mock_response = mock.Mock()
     mock_response.return_value = {}
-    self.mock_watcher._GetMetadataUpdate = mock_response
+    self.mock_watcher._HandleMetadataUpdate = mock_response
     metadata_key = 'instance/id'
     recursive = False
 
@@ -246,15 +282,6 @@ class MetadataWatcherTest(unittest.TestCase):
     mock_response.assert_called_once_with(
         metadata_key=metadata_key, recursive=False, wait=False)
     self.mock_watcher.logger.error.assert_not_called()
-
-  def testGetMetadataException(self):
-    mock_response = mock.Mock()
-    mock_response.side_effect = metadata_watcher.socket.timeout()
-    mock_response.return_value = {}
-    self.mock_watcher._GetMetadataUpdate = mock_response
-
-    self.assertEqual(self.mock_watcher.GetMetadata(), None)
-    self.assertEqual(self.mock_watcher.logger.error.call_count, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* An error message should only be printed once to prevent log spam.
* Calls to the metadata watcher will retry until metadata is retrieved.