### PR TITLE
Add a null handler to GCE loggers

### DIFF
--- a/google_compute_engine/compat.py
+++ b/google_compute_engine/compat.py
@@ -15,13 +15,13 @@
 
 """A module for resolving compatibility issues between Python 2 and Python 3."""
 
+import logging
 import sys
 
 if sys.version_info >= (3,):
   # Python 3 imports.
   import configparser as parser
   import http.client as httpclient
-  from logging import NullHandler
   import urllib.error as urlerror
   import urllib.parse as urlparse
   import urllib.request as urlrequest
@@ -30,22 +30,21 @@ else:
   # Python 2 imports.
   import ConfigParser as parser
   import httplib as httpclient
-
-  import logging
-  try:  # Python 2.7+
-      from logging import NullHandler
-  except ImportError:
-      class NullHandler(logging.Handler):
-          def emit(self, record):
-              pass
-
-          def handle(self, record):
-              pass
-
-          def createLock(self):
-              pass
-
   import urllib as urlparse
   import urllib as urlretrieve
   import urllib2 as urlrequest
   import urllib2 as urlerror
+
+if sys.version_info < (2,7,):
+  class NullHandler(logging.Handler):
+    def emit(self, record):
+      pass
+
+    def handle(self, record):
+      pass
+
+    def createLock(self):
+      pass
+
+  logging.NullHandler = NullHandler
+

--- a/google_compute_engine/compat.py
+++ b/google_compute_engine/compat.py
@@ -47,4 +47,3 @@ if sys.version_info < (2,7,):
       pass
 
   logging.NullHandler = NullHandler
-

--- a/google_compute_engine/compat.py
+++ b/google_compute_engine/compat.py
@@ -21,6 +21,7 @@ if sys.version_info >= (3,):
   # Python 3 imports.
   import configparser as parser
   import http.client as httpclient
+  from logging import NullHandler
   import urllib.error as urlerror
   import urllib.parse as urlparse
   import urllib.request as urlrequest
@@ -29,6 +30,21 @@ else:
   # Python 2 imports.
   import ConfigParser as parser
   import httplib as httpclient
+
+  import logging
+  try:  # Python 2.7+
+      from logging import NullHandler
+  except ImportError:
+      class NullHandler(logging.Handler):
+          def emit(self, record):
+              pass
+
+          def handle(self, record):
+              pass
+
+          def createLock(self):
+              pass
+
   import urllib as urlparse
   import urllib as urlretrieve
   import urllib2 as urlrequest

--- a/google_compute_engine/logger.py
+++ b/google_compute_engine/logger.py
@@ -18,6 +18,8 @@
 import logging
 import logging.handlers
 
+from google_compute_engine.compat import NullHandler
+
 
 def Logger(name, debug=False, facility=None):
   """Get a logging object with handlers for sending logs to SysLog.
@@ -32,7 +34,7 @@ def Logger(name, debug=False, facility=None):
   """
   logger = logging.getLogger(name)
   logger.handlers = []
-  logger.addHandler(logging.NullHandler())
+  logger.addHandler(NullHandler())
   logger.propagate = False
   logger.setLevel(logging.DEBUG)
   formatter = logging.Formatter(name + ': %(levelname)s %(message)s')

--- a/google_compute_engine/logger.py
+++ b/google_compute_engine/logger.py
@@ -18,7 +18,7 @@
 import logging
 import logging.handlers
 
-from google_compute_engine.compat import NullHandler
+from google_compute_engine.compat import logging
 
 
 def Logger(name, debug=False, facility=None):
@@ -34,7 +34,7 @@ def Logger(name, debug=False, facility=None):
   """
   logger = logging.getLogger(name)
   logger.handlers = []
-  logger.addHandler(NullHandler())
+  logger.addHandler(logging.NullHandler())
   logger.propagate = False
   logger.setLevel(logging.DEBUG)
   formatter = logging.Formatter(name + ': %(levelname)s %(message)s')

--- a/google_compute_engine/logger.py
+++ b/google_compute_engine/logger.py
@@ -32,6 +32,7 @@ def Logger(name, debug=False, facility=None):
   """
   logger = logging.getLogger(name)
   logger.handlers = []
+  logger.addHandler(logging.NullHandler())
   logger.propagate = False
   logger.setLevel(logging.DEBUG)
   formatter = logging.Formatter(name + ': %(levelname)s %(message)s')

--- a/google_compute_engine/logger.py
+++ b/google_compute_engine/logger.py
@@ -15,9 +15,6 @@
 
 """A library for logging text to SysLog and the serial console."""
 
-import logging
-import logging.handlers
-
 from google_compute_engine.compat import logging
 
 

--- a/google_compute_engine/tests/logger_test.py
+++ b/google_compute_engine/tests/logger_test.py
@@ -43,8 +43,7 @@ class LoggerTest(unittest.TestCase):
     mock_syslog.assert_called_once_with(address=address, facility=facility)
     mock_syslog.setLevel.assert_called_once_with(logger.logging.INFO)
     self.assertEqual(
-        named_logger.handlers,
-        [mock_null, mock_stream, mock_syslog])
+        named_logger.handlers, [mock_null, mock_stream, mock_syslog])
 
     # Verify the handlers are reset during repeated calls.
     named_logger = logger.Logger(name=name, debug=False)

--- a/google_compute_engine/tests/logger_test.py
+++ b/google_compute_engine/tests/logger_test.py
@@ -24,7 +24,7 @@ class LoggerTest(unittest.TestCase):
 
   @mock.patch('google_compute_engine.logger.logging.handlers.SysLogHandler')
   @mock.patch('google_compute_engine.logger.logging.StreamHandler')
-  @mock.patch('google_compute_engine.logger.logging.NullHandler')
+  @mock.patch('google_compute_engine.logger.NullHandler')
   def testLogger(self, mock_null, mock_stream, mock_syslog):
     mock_null.return_value = mock_null
     mock_stream.return_value = mock_stream

--- a/google_compute_engine/tests/logger_test.py
+++ b/google_compute_engine/tests/logger_test.py
@@ -24,7 +24,7 @@ class LoggerTest(unittest.TestCase):
 
   @mock.patch('google_compute_engine.logger.logging.handlers.SysLogHandler')
   @mock.patch('google_compute_engine.logger.logging.StreamHandler')
-  @mock.patch('google_compute_engine.logger.NullHandler')
+  @mock.patch('google_compute_engine.logger.logging.NullHandler')
   def testLogger(self, mock_null, mock_stream, mock_syslog):
     mock_null.return_value = mock_null
     mock_stream.return_value = mock_stream


### PR DESCRIPTION
This fixes an issue where the compute auth boto plugin would
emit a warning message to the root logger that no handlers
could be found for the "compute-auth" logger when a
GCE service account was not configured.