### PR TITLE
Fix dependencies for init package. Update google-compute-engine-init to 2.0.1.

### DIFF
--- a/google_compute_engine_init/build_packages.sh
+++ b/google_compute_engine_init/build_packages.sh
@@ -20,7 +20,8 @@ function build_distro() {
   declare -r pkg_type="$2"
   declare -r init_config="$3"
   declare -r init_prefix="$4"
-  declare depends='google-compute-engine'
+  declare py_depends='google-compute-engine'
+  declare config_depends='google-config'
   declare file_pattern='*[^.sh]'
   declare init_files=(${init_config}/${file_pattern})
   declare name='google-compute-engine-init'
@@ -32,7 +33,8 @@ function build_distro() {
   done
 
   if [[ "${pkg_type}" == 'deb' ]]; then
-    depends="${depends}-${distro}"
+    py_depends="${py_depends}-${distro}"
+    config_depends="${config_depends}-${distro}"
     name="${name}-${distro}"
   fi
 
@@ -41,7 +43,8 @@ function build_distro() {
     -t "${pkg_type}" \
     --after-install "${init_config}/postinst.sh" \
     --before-remove "${init_config}/prerm.sh" \
-    --depends "${depends}" \
+    --depends "${py_depends}" \
+    --depends "${config_depends}" \
     --description 'Google Compute Engine Linux initialization scripts' \
     --iteration "0.${TIMESTAMP}" \
     --license 'Apache Software License' \

--- a/google_compute_engine_init/systemd/postinst.sh
+++ b/google_compute_engine_init/systemd/postinst.sh
@@ -26,6 +26,9 @@ systemctl enable google-ip-forwarding-daemon.service
 systemctl enable google-shutdown-scripts.service
 systemctl enable google-startup-scripts.service
 
+# Run instance setup.
+systemctl start --no-block google-instance-setup
+
 # Start daemons.
 systemctl start --no-block google-accounts-daemon
 systemctl start --no-block google-clock-skew-daemon

--- a/google_compute_engine_init/sysvinit/postinst.sh
+++ b/google_compute_engine_init/sysvinit/postinst.sh
@@ -19,3 +19,6 @@ update-rc.d google-instance-setup defaults
 update-rc.d google-ip-forwarding-daemon defaults
 update-rc.d google-shutdown-scripts defaults
 update-rc.d google-startup-scripts defaults
+
+# Run instance setup.
+/etc/init.d/google-instance-setup start

--- a/google_compute_engine_init/upstart/postinst.sh
+++ b/google_compute_engine_init/upstart/postinst.sh
@@ -18,6 +18,9 @@ stop --no-wait google-accounts-daemon
 stop --no-wait google-clock-skew-daemon
 stop --no-wait google-ip-forwarding-daemon
 
+# Run instance setup
+start --no-wait google-instance-setup
+
 # Start daemons
 start --no-wait google-accounts-daemon
 start --no-wait google-clock-skew-daemon


### PR DESCRIPTION
We need to depend on google-configs package as well to handle previous guest updates properly.