### PR TITLE
Fix migration from existing guest environment to new guest environment.

### DIFF
--- a/google_compute_engine_init/build_packages.sh
+++ b/google_compute_engine_init/build_packages.sh
@@ -55,6 +55,8 @@ function build_distro() {
     --replaces 'google-compute-daemon' \
     --replaces 'google-startup-scripts' \
     --rpm-dist "${distro}" \
+    --rpm-trigger-after-target-uninstall \
+      "google-compute-daemon: ${init_config}/rpm_replace" \
     --url 'https://github.com/GoogleCloudPlatform/compute-image-packages' \
     --vendor 'Google Compute Engine Team' \
     --version '2.0.1' \

--- a/google_compute_engine_init/systemd/postinst.sh
+++ b/google_compute_engine_init/systemd/postinst.sh
@@ -26,8 +26,8 @@ systemctl enable google-ip-forwarding-daemon.service
 systemctl enable google-shutdown-scripts.service
 systemctl enable google-startup-scripts.service
 
-# Run instance setup.
-systemctl start --no-block google-instance-setup
+# Run instance setup manually to prevent startup script execution.
+/usr/bin/google_instance_setup
 
 # Start daemons.
 systemctl start --no-block google-accounts-daemon

--- a/google_compute_engine_init/systemd/rpm_replace
+++ b/google_compute_engine_init/systemd/rpm_replace
@@ -1,0 +1,17 @@
+# Replace existing guest in EL7.
+
+# Enable systemd services.
+systemctl enable google-accounts-daemon.service
+systemctl enable google-clock-skew-daemon.service
+systemctl enable google-instance-setup.service
+systemctl enable google-ip-forwarding-daemon.service
+systemctl enable google-shutdown-scripts.service
+systemctl enable google-startup-scripts.service
+
+# Run instance setup manually.
+/usr/bin/google_instance_setup
+
+# Start daemons.
+systemctl start --no-block google-accounts-daemon
+systemctl start --no-block google-clock-skew-daemon
+systemctl start --no-block google-ip-forwarding-daemon

--- a/google_compute_engine_init/sysvinit/rpm_replace
+++ b/google_compute_engine_init/sysvinit/rpm_replace
@@ -1,0 +1,4 @@
+# Replace existing guest.
+
+# Run instance setup.
+/usr/bin/google_instance_setup

--- a/google_compute_engine_init/upstart/postinst.sh
+++ b/google_compute_engine_init/upstart/postinst.sh
@@ -18,8 +18,8 @@ stop --no-wait google-accounts-daemon
 stop --no-wait google-clock-skew-daemon
 stop --no-wait google-ip-forwarding-daemon
 
-# Run instance setup
-start --no-wait google-instance-setup
+# Run instance setup manually to prevent startup script execution.
+/usr/bin/google_instance_setup
 
 # Start daemons
 start --no-wait google-accounts-daemon

--- a/google_compute_engine_init/upstart/rpm_replace
+++ b/google_compute_engine_init/upstart/rpm_replace
@@ -1,0 +1,9 @@
+# Replace existing guest in EL6.
+
+# Run instance setup
+/usr/bin/google_instance_setup
+
+# Manually start daemon's
+start --no-wait google-accounts-daemon
+start --no-wait google-clock-skew-daemon
+start --no-wait google-ip-forwarding-daemon


### PR DESCRIPTION
Specifically, in EL7 systemd will still not be setup properly in some instances of guest env migration. Specifying a trigger to run after uninstalling the old package to re-enable the new services and run instance setup fixes this problem.

In EL6, upstart would run startup scripts again because google-instance-setup, the init job, had run. Run it manually instead of with upstart to prevent startup scripts from running.