### PR TITLE
Add user to docker group if exists.

### DIFF
--- a/google_compute_engine/instance_setup/instance_config.py
+++ b/google_compute_engine/instance_setup/instance_config.py
@@ -41,7 +41,7 @@ class InstanceConfig(config_manager.ConfigManager):
   instance_config_options = {
       'Accounts': {
           'deprovision_remove': 'false',
-          'groups': 'adm,dip,lxd,plugdev,video',
+          'groups': 'adm,dip,docker,lxd,plugdev,video',
       },
       'Daemons': {
           'accounts_daemon': 'true',


### PR DESCRIPTION
If the user has sudo access, they will already have access to `sudo docker`. This helps usability by removing the need to use sudo. Also, it solves problems where the `/root` directory is mounted read-only on GCI and `sudo docker` cannot save any config to `/root/.docker`