### PR TITLE
[RFC] Add support for RHEL5

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -21,6 +21,7 @@ function build_distro() {
   declare -r distro="$1"
   declare -r pkg_type="$2"
   declare -r py_path="$3"
+  declare -r py_pkt="$4"
   declare depends='google-compute-engine-init'
   declare name='google-compute-engine'
 
@@ -35,8 +36,8 @@ function build_distro() {
     -s python \
     -t "${pkg_type}" \
     --depends "${depends}" \
-    --depends 'python-boto' \
-    --depends 'python-setuptools' \
+    --depends "${py_pkt}-boto" \
+    --depends "${py_pkt}-setuptools" \
     --iteration "0.${TIMESTAMP}" \
     --maintainer 'gc-team@google.com' \
     --name "${name}" \
@@ -45,13 +46,15 @@ function build_distro() {
     --python-install-lib "${py_path}" \
     --python-install-data "/usr/share/doc/${name}" \
     --rpm-dist "${distro}" \
+    --python-scripts-executable "/usr/bin/${py_pkt}" \
     setup.py
 }
 
 # RHEL/CentOS
-build_distro 'el6' 'rpm' '/usr/lib/python2.6/site-packages'
-build_distro 'el7' 'rpm' '/usr/lib/python2.7/site-packages'
+build_distro 'el5' 'rpm' '/usr/lib/python2.6/site-packages' 'python26'
+build_distro 'el6' 'rpm' '/usr/lib/python2.6/site-packages' 'python'
+build_distro 'el7' 'rpm' '/usr/lib/python2.7/site-packages' 'python'
 
 # Debian
-build_distro 'wheezy' 'deb' '/usr/lib/python2.7/dist-packages'
-build_distro 'jessie' 'deb' '/usr/lib/python2.7/dist-packages'
+build_distro 'wheezy' 'deb' '/usr/lib/python2.7/dist-packages' 'python'
+build_distro 'jessie' 'deb' '/usr/lib/python2.7/dist-packages' 'python'

--- a/google_compute_engine_init/build_packages.sh
+++ b/google_compute_engine_init/build_packages.sh
@@ -64,6 +64,7 @@ function build_distro() {
 }
 
 # RHEL/CentOS
+build_distro 'el5' 'rpm' 'sysvinit-rhel5' '/etc/init.d'
 build_distro 'el6' 'rpm' 'upstart' '/etc/init'
 build_distro 'el7' 'rpm' 'systemd' '/usr/lib/systemd/system'
 

--- a/google_compute_engine_init/build_packages.sh
+++ b/google_compute_engine_init/build_packages.sh
@@ -22,7 +22,7 @@ function build_distro() {
   declare -r init_prefix="$4"
   declare py_depends='google-compute-engine'
   declare config_depends='google-config'
-  declare file_pattern='*[^.sh]'
+  declare file_pattern='*[^.s][^.h]'
   declare init_files=(${init_config}/${file_pattern})
   declare name='google-compute-engine-init'
 

--- a/google_compute_engine_init/sysvinit-rhel5/google-accounts-daemon
+++ b/google_compute_engine_init/sysvinit-rhel5/google-accounts-daemon
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+### BEGIN INIT INFO
+# Provides:          $google_accounts_daemon
+# X-Start-Before:    ssh
+# Required-Start:    $local_fs $network $named $syslog $google_instance_setup
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Google Compute Engine Accounts Daemon
+# Description:       Manages accounts from metadata SSH keys.
+### END INIT INFO
+
+# Do NOT "set -e".
+
+NAME=google-accounts-daemon
+DAEMON=/usr/bin/google_accounts_daemon
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed.
+[ -x "$DAEMON" ] || exit 0
+
+# source function library
+. /etc/init.d/functions
+
+#
+# Function that starts the daemon/service.
+#
+do_start()
+{
+  echo -n $"Starting $NAME:"
+  daemon --pidfile $PIDFILE "$DAEMON &"
+  touch $PIDFILE
+  # workaround: when the system boots sometime the pid is not
+  # ready righ away, wait a little
+  usleep 100000
+  PID="$(__pids_pidof "$DAEMON")"
+  #echo "Saving PID" $PID " to " $PIDFILE
+  if [ ! -z "$PID" ]; then
+      echo $PID > $PIDFILE
+  fi
+  echo ""
+}
+
+#
+# Function that stops the daemon/service.
+#
+do_stop()
+{
+  echo -n $"Stopping $NAME:"
+  killproc -p $PIDFILE $DAEMON
+  # Delete the pidfile when the daemon exits.
+  rm -f $PIDFILE
+  echo ""
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+  stop)
+    do_stop
+    ;;
+  status)
+    status "$DAEMON" "$NAME" && exit 0 || exit $?
+    ;;
+  restart|force-reload)
+    do_stop
+    do_start
+    ;;
+  *)
+    echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+    exit 1
+    ;;
+esac
+
+:

--- a/google_compute_engine_init/sysvinit-rhel5/google-clock-skew-daemon
+++ b/google_compute_engine_init/sysvinit-rhel5/google-clock-skew-daemon
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+### BEGIN INIT INFO
+# Provides:          $google_clock_skew_daemon
+# Required-Start:    $network $syslog $google_instance_setup
+# Required-Stop:     $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Google Compute Engine Clock Skew Daemon
+# Description:       Sync the system clock on migration.
+### END INIT INFO
+
+# Do NOT "set -e".
+
+NAME=google-clock-skew-daemon
+DAEMON=/usr/bin/google_clock_skew_daemon
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed.
+[ -x "$DAEMON" ] || exit 0
+
+# source function library
+. /etc/init.d/functions
+
+#
+# Function that starts the daemon/service.
+#
+do_start()
+{
+  echo -n $"Starting $NAME:"
+  daemon --pidfile $PIDFILE "$DAEMON &"
+  touch $PIDFILE
+  # workaround: when the system boots sometime the pid is not
+  # ready righ away, wait a little
+  usleep 100000
+  PID="$(__pids_pidof "$DAEMON")"
+  #echo "Saving PID" $PID " to " $PIDFILE
+  if [ ! -z "$PID" ]; then
+      echo $PID > $PIDFILE
+  fi
+  echo ""
+}
+
+#
+# Function that stops the daemon/service.
+#
+do_stop()
+{
+  echo -n $"Stopping $NAME:"
+  killproc -p $PIDFILE $DAEMON
+  # Delete the pidfile when the daemon exits.
+  rm -f $PIDFILE
+  echo ""
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+  stop)
+    do_stop
+    ;;
+  status)
+    status "$DAEMON" "$NAME" && exit 0 || exit $?
+    ;;
+  restart|force-reload)
+    do_stop
+    do_start
+    ;;
+  *)
+    echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+    exit 1
+    ;;
+esac
+
+:

--- a/google_compute_engine_init/sysvinit-rhel5/google-instance-setup
+++ b/google_compute_engine_init/sysvinit-rhel5/google-instance-setup
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+### BEGIN INIT INFO
+# Provides:          $google_instance_setup
+# X-Start-Before:    ssh
+# Required-Start:    $local_fs $network $syslog
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Google Compute Engine Instance Setup
+# Description:       Runs instance setup on boot.
+### END INIT INFO
+
+NAME=google-instance-setup
+SCRIPTNAME=/etc/init.d/$NAME
+
+# source function library
+. /etc/init.d/functions
+
+#
+# Function that starts the daemon/service.
+#
+do_start()
+{
+  /usr/bin/google_instance_setup > /dev/null
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+  *)
+    echo "Usage: $SCRIPTNAME start" >&2
+    exit 1
+    ;;
+esac
+
+:

--- a/google_compute_engine_init/sysvinit-rhel5/google-ip-forwarding-daemon
+++ b/google_compute_engine_init/sysvinit-rhel5/google-ip-forwarding-daemon
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+### BEGIN INIT INFO
+# Provides:          $google_ip_forwarding_daemon
+# Required-Start:    $network $syslog $google_instance_setup
+# Required-Stop:     $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Google Compute Engine IP Forwarding Daemon
+# Description:       Manages IP forwarding.
+### END INIT INFO
+
+# Do NOT "set -e".
+
+NAME=google-ip-forwarding-daemon
+DAEMON=/usr/bin/google_ip_forwarding_daemon
+PIDFILE=/var/run/$NAME.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed.
+[ -x "$DAEMON" ] || exit 0
+
+# source function library
+. /etc/init.d/functions
+
+#
+# Function that starts the daemon/service.
+#
+do_start()
+{
+  echo -n $"Starting $NAME:"
+  daemon --pidfile $PIDFILE "$DAEMON &"
+  touch $PIDFILE
+  # workaround: when the system boots sometime the pid is not
+  # ready righ away, wait a little
+  usleep 100000
+  PID="$(__pids_pidof "$DAEMON")"
+  #echo "Saving PID" $PID " to " $PIDFILE
+  if [ ! -z "$PID" ]; then
+      echo $PID > $PIDFILE
+  fi
+  echo ""
+}
+
+#
+# Function that stops the daemon/service.
+#
+do_stop()
+{
+  echo -n $"Stopping $NAME:"
+  killproc -p $PIDFILE $DAEMON
+  # Delete the pidfile when the daemon exits.
+  rm -f $PIDFILE
+  echo ""
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+  stop)
+    do_stop
+    ;;
+  status)
+    status "$DAEMON" "$NAME" && exit 0 || exit $?
+    ;;
+  restart|force-reload)
+    do_stop
+    do_start
+    ;;
+  *)
+    echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+    exit 1
+    ;;
+esac
+
+:

--- a/google_compute_engine_init/sysvinit-rhel5/google-shutdown-scripts
+++ b/google_compute_engine_init/sysvinit-rhel5/google-shutdown-scripts
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+### BEGIN INIT INFO
+# Provides:          $google_shutdown_scripts
+# Required-Start:
+# Required-Stop:     $remote_fs $syslog docker kubelet
+# Default-Start:     1 2 3 4 5
+# Default-Stop:      0 6
+# Short-Description: Google Compute Engine Shutdown Scripts
+# Description:       Runs user specified shutdown scripts from metadata.
+### END INIT INFO
+
+NAME=google-shutdown-scripts
+SCRIPTNAME=/etc/init.d/$NAME
+
+# source function library
+. /etc/init.d/functions
+
+#
+# Function that stops the daemon/service.
+#
+do_stop()
+{
+  /usr/bin/google_metadata_script_runner --script-type shutdown > /dev/null
+}
+
+case "$1" in
+  start)
+    # Necessary to allow stop to be called on shutdown
+    touch /var/lock/subsys/$NAME
+    ;;
+  stop)
+    do_stop
+    rm /var/lock/subsys/$NAME
+    ;;
+  *)
+    echo "Usage: $SCRIPTNAME stop" >&2
+    exit 1
+    ;;
+esac
+
+:

--- a/google_compute_engine_init/sysvinit-rhel5/google-startup-scripts
+++ b/google_compute_engine_init/sysvinit-rhel5/google-startup-scripts
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
+### BEGIN INIT INFO
+# Provides:          $google_startup_scripts
+# Required-Start:    $all $google_instance_setup
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Google Compute Engine Startup Scripts
+# Description:       Runs user specified startup scripts from metadata.
+### END INIT INFO
+
+NAME=google-startup-scripts
+SCRIPTNAME=/etc/init.d/$NAME
+
+# source function library
+. /etc/init.d/functions
+
+#
+# Function that starts the daemon/service.
+#
+do_start()
+{
+  /usr/bin/google_metadata_script_runner --script-type startup > /dev/null
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+  *)
+    echo "Usage: $SCRIPTNAME start" >&2
+    exit 1
+    ;;
+esac
+
+:

--- a/google_compute_engine_init/sysvinit-rhel5/postinst.sh
+++ b/google_compute_engine_init/sysvinit-rhel5/postinst.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+chkconfig --add google-accounts-daemon
+chkconfig --add google-clock-skew-daemon
+chkconfig --add google-instance-setup
+chkconfig --add google-ip-forwarding-daemon
+chkconfig --add google-shutdown-scripts
+chkconfig --add google-startup-scripts

--- a/google_compute_engine_init/sysvinit-rhel5/prerm.sh
+++ b/google_compute_engine_init/sysvinit-rhel5/prerm.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "$1" = purge ]; then
+  chkconfig --del google-accounts-daemon
+  chkconfig --del google-clock-skew-daemon
+  chkconfig --del google-instance-setup
+  chkconfig --del google-ip-forwarding-daemon
+  chkconfig --del google-shutdown-scripts
+  chkconfig --del google-startup-scripts
+fi

--- a/google_configs/build_packages.sh
+++ b/google_configs/build_packages.sh
@@ -46,6 +46,10 @@ function build_distro() {
     "${files[@]:2}"
 }
 
+# RHEL/CentOS 5
+build_distro 'el5' 'rpm' \
+  'bin/set_hostname=/etc/dhclient-exit-hooks'
+
 # RHEL/CentOS 6
 build_distro 'el6' 'rpm' \
   'bin/set_hostname=/etc/dhcp/dhclient-exit-hooks'


### PR DESCRIPTION
Add support for RHEL5 in google-compute-engine, google-compute-engine-init and google-config

* Add sysvinit-rhel5 folder
* Fix pattern in build_packages script to include the startup/shutdown scripts in the build
* RHEL5 doesn't use the /etc/sudoers.d/ folder, use /etc/sudoers file if the folder doesn't exist