### PR TITLE
Fix user account management on Python 3.

### DIFF
--- a/google_compute_engine/accounts/accounts_utils.py
+++ b/google_compute_engine/accounts/accounts_utils.py
@@ -50,7 +50,7 @@ class AccountsUtils(object):
     self._CreateSudoersGroup()
     self.groups = groups.split(',') if groups else []
     self.groups.append(self.google_sudoers_group)
-    self.groups = filter(self._GetGroup, self.groups)
+    self.groups = list(filter(self._GetGroup, self.groups))
     self.remove = remove
 
   def _GetGroup(self, group):

--- a/google_compute_engine/accounts/accounts_utils.py
+++ b/google_compute_engine/accounts/accounts_utils.py
@@ -140,8 +140,9 @@ class AccountsUtils(object):
     Returns:
       bool, True if user update succeeded.
     """
+    groups = ','.join(groups)
     self.logger.debug('Updating user %s with groups %s.', user, groups)
-    command = ['usermod', '-G', ','.join(groups), user]
+    command = ['usermod', '-G', groups, user]
     try:
       subprocess.check_call(command)
     except subprocess.CalledProcessError as e:

--- a/google_compute_engine/accounts/tests/accounts_utils_test.py
+++ b/google_compute_engine/accounts/tests/accounts_utils_test.py
@@ -194,14 +194,15 @@ class AccountsUtilsTest(unittest.TestCase):
   def testUpdateUserGroups(self, mock_call):
     user = 'user'
     groups = ['a', 'b', 'c']
-    command = ['usermod', '-G', 'a,b,c', user]
+    groups_string = ','.join(groups)
+    command = ['usermod', '-G', groups_string, user]
 
     self.assertTrue(
         accounts_utils.AccountsUtils._UpdateUserGroups(
             self.mock_utils, user, groups))
     mock_call.assert_called_once_with(command)
     expected_calls = [
-        mock.call.debug(mock.ANY, user, groups),
+        mock.call.debug(mock.ANY, user, groups_string),
         mock.call.debug(mock.ANY, user),
     ]
     self.assertEqual(self.mock_logger.mock_calls, expected_calls)
@@ -210,7 +211,8 @@ class AccountsUtilsTest(unittest.TestCase):
   def testUpdateUserGroupsError(self, mock_call):
     user = 'user'
     groups = ['a', 'b', 'c']
-    command = ['usermod', '-G', 'a,b,c', user]
+    groups_string = ','.join(groups)
+    command = ['usermod', '-G', groups_string, user]
     mock_call.side_effect = subprocess.CalledProcessError(1, 'Test')
 
     self.assertFalse(
@@ -218,7 +220,7 @@ class AccountsUtilsTest(unittest.TestCase):
             self.mock_utils, user, groups))
     mock_call.assert_called_once_with(command)
     expected_calls = [
-        mock.call.debug(mock.ANY, user, groups),
+        mock.call.debug(mock.ANY, user, groups_string),
         mock.call.warning(mock.ANY, user, mock.ANY),
     ]
     self.assertEqual(self.mock_logger.mock_calls, expected_calls)


### PR DESCRIPTION
Filter returns an iterator in Python 3, rather than a list.