### PR TITLE
Ignore build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .tox
 .coverage
 *.egg-info
+build
+*.deb
+*.rpm
 
 # emacs backup files
 *.*~


### PR DESCRIPTION
From running https://github.com/GoogleCloudPlatform/compute-image-packages/pull/333#issuecomment-244439071,

```bash
$ git status
On branch gnawhleinad/build-distro
Your branch is up-to-date with 'origin/gnawhleinad/build-distro'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	build/
	google-compute-engine-jessie_2.2.2-0.1472837492_all.deb
	google-compute-engine-jessie_2.2.2-0.1472837504_all.deb
	google-compute-engine-wheezy_2.2.2-0.1472837504_all.deb
```