### PR TITLE
Check for existence of external executable

### DIFF
--- a/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/google_compute_engine/metadata_scripts/script_retriever.py
@@ -50,6 +50,18 @@ class ScriptRetriever(object):
     Returns:
       string, the path to the file storing the metadata script.
     """
+    try:
+       subprocess.check_call(
+         ['which', 'gsutil'],
+         stdout=subprocess.PIPE,
+         stderr=subprocess.PIPE
+       )
+    except subprocess.CalledProcessError:
+      self.logger.warning(
+        'gsutil is not installed, cannot download items from Google Storage'
+      )
+      return None
+
     dest_file = tempfile.NamedTemporaryFile(dir=dest_dir, delete=False)
     dest_file.close()
     dest = dest_file.name

--- a/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/google_compute_engine/metadata_scripts/script_retriever.py
@@ -51,11 +51,11 @@ class ScriptRetriever(object):
       string, the path to the file storing the metadata script.
     """
     try:
-       subprocess.check_call(
-         ['which', 'gsutil'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      subprocess.check_call(
+          ['which', 'gsutil'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
       self.logger.warning(
-        'gsutil is not installed, cannot download items from Google Storage')
+          'gsutil is not installed, cannot download items from Google Storage')
       return None
 
     dest_file = tempfile.NamedTemporaryFile(dir=dest_dir, delete=False)

--- a/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/google_compute_engine/metadata_scripts/script_retriever.py
@@ -52,14 +52,10 @@ class ScriptRetriever(object):
     """
     try:
        subprocess.check_call(
-         ['which', 'gsutil'],
-         stdout=subprocess.PIPE,
-         stderr=subprocess.PIPE
-       )
+         ['which', 'gsutil'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
       self.logger.warning(
-        'gsutil is not installed, cannot download items from Google Storage'
-      )
+        'gsutil is not installed, cannot download items from Google Storage')
       return None
 
     dest_file = tempfile.NamedTemporaryFile(dir=dest_dir, delete=False)

--- a/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
+++ b/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
@@ -39,7 +39,7 @@ class ScriptRetrieverTest(unittest.TestCase):
     gs_url = 'gs://fake/url'
     self.assertIsNone(self.retriever._DownloadGsUrl(gs_url, self.dest_dir))
     mock_call.assert_called_once_with(
-      ['which', 'gsutil'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        ['which', 'gsutil'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     self.mock_logger.warning.assert_called_once_with(mock.ANY)
 
   @mock.patch('google_compute_engine.metadata_scripts.script_retriever.subprocess.check_call')
@@ -62,7 +62,7 @@ class ScriptRetrieverTest(unittest.TestCase):
     gs_url = 'gs://fake/url'
     mock_tempfile.return_value = mock_tempfile
     mock_tempfile.name = self.dest
-    mock_call.side_effect = subprocess.CalledProcessError(1, 'Test')
+    mock_call.side_effect = [0, subprocess.CalledProcessError(1, 'Test')]
     self.assertIsNone(self.retriever._DownloadGsUrl(gs_url, self.dest_dir))
     self.assertEqual(self.mock_logger.warning.call_count, 1)
 

--- a/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
+++ b/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
@@ -34,6 +34,15 @@ class ScriptRetrieverTest(unittest.TestCase):
         self.mock_logger, self.script_type)
 
   @mock.patch('google_compute_engine.metadata_scripts.script_retriever.subprocess.check_call')
+  def testDownloadGsNoExec(self, mock_call):
+    mock_call.side_effect = subprocess.CalledProcessError('foo', 'bar')
+    gs_url = 'gs://fake/url'
+    self.assertIsNone(self.retriever._DownloadGsUrl(gs_url, self.dest_dir))
+    mock_call.assert_called_once_with(
+      ['which', 'gsutil'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    self.mock_logger.warning.assert_called_once_with(mock.ANY)
+
+  @mock.patch('google_compute_engine.metadata_scripts.script_retriever.subprocess.check_call')
   @mock.patch('google_compute_engine.metadata_scripts.script_retriever.tempfile.NamedTemporaryFile')
   def testDownloadGsUrl(self, mock_tempfile, mock_call):
     gs_url = 'gs://fake/url'
@@ -44,7 +53,7 @@ class ScriptRetrieverTest(unittest.TestCase):
     mock_tempfile.assert_called_once_with(dir=self.dest_dir, delete=False)
     mock_tempfile.close.assert_called_once_with()
     self.mock_logger.info.assert_called_once_with(mock.ANY, gs_url, self.dest)
-    mock_call.assert_called_once_with(['gsutil', 'cp', gs_url, self.dest])
+    mock_call.assert_called_with(['gsutil', 'cp', gs_url, self.dest])
     self.mock_logger.warning.assert_not_called()
 
   @mock.patch('google_compute_engine.metadata_scripts.script_retriever.subprocess.check_call')
@@ -63,7 +72,7 @@ class ScriptRetrieverTest(unittest.TestCase):
     gs_url = 'gs://fake/url'
     mock_tempfile.return_value = mock_tempfile
     mock_tempfile.name = self.dest
-    mock_call.side_effect = Exception('Error.')
+    mock_call.side_effect = [0, Exception('Error.')]
     self.assertIsNone(self.retriever._DownloadGsUrl(gs_url, self.dest_dir))
     self.assertEqual(self.mock_logger.warning.call_count, 1)
 


### PR DESCRIPTION
  + With the check we can exit early and provide a message to the user
    that the executable is missing, rather than having the information about
    the missing executable intermingled with a failed call thereof. Last
    but not least it avoids the message that indicates that a download is
    being attempted, which could lead to confusion.