### PR TITLE
Add setuptools as a package dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     author_email='gc-team@google.com',
     description='Google Compute Engine',
     include_package_data=True,
-    install_requires=['boto'],
+    install_requires=['boto', 'setuptools'],
     license='Apache Software License',
     long_description='Google Compute Engine guest environment.',
     name='google-compute-engine',


### PR DESCRIPTION
  + The setup.py file is used to generate scripts. The generated scripts
    create a runtime dependence on the setuptools, thus these must be
    installed on the target system where the code is supposed to run.