### PR TITLE
Fix rsyslog startup problem on systemd.

### DIFF
--- a/google_config/bin/set_hostname
+++ b/google_config/bin/set_hostname
@@ -36,6 +36,10 @@ fi
 if [ -n "$new_host_name" ]; then
   hostname "${new_host_name%%.*}"
 
-  # Let syslogd know we've changed the hostname.
-  pkill -HUP syslogd
+  # Restart syslog to update the hostname if we're not using systemd.
+  # systemd rsyslog jobs wait for networking to finish starting and consequently
+  # syslog or rsyslog is running with the correct hostname.
+  if [ ! -f /bin/systemctl ]; then
+    pkill -HUP syslogd
+  fi
 fi


### PR DESCRIPTION
Systems as rsyslog already waits for the network. A race condition can be triggered in EL7 which will cause rsyslog not to start.