### PR TITLE
Remove setting home directory permissions.

### DIFF
--- a/google_compute_engine/accounts/accounts_utils.py
+++ b/google_compute_engine/accounts/accounts_utils.py
@@ -179,8 +179,6 @@ class AccountsUtils(object):
     home_dir = pw_entry.pw_dir
     ssh_dir = os.path.join(home_dir, '.ssh')
     file_utils.SetPermissions(
-        home_dir, mode=0o750, uid=uid, gid=gid, mkdir=True)
-    file_utils.SetPermissions(
         ssh_dir, mode=0o700, uid=uid, gid=gid, mkdir=True)
 
     # Not all sshd's support multiple authorized_keys files so we have to

--- a/google_compute_engine/accounts/tests/accounts_utils_test.py
+++ b/google_compute_engine/accounts/tests/accounts_utils_test.py
@@ -298,7 +298,6 @@ class AccountsUtilsTest(unittest.TestCase):
     self.assertEqual(mock_tempfile.mock_calls, expected_calls)
     mock_copy.assert_called_once_with(temp_dest, authorized_keys_file)
     expected_calls = [
-        mock.call(pw_dir, mode=0o750, uid=pw_uid, gid=pw_gid, mkdir=True),
         mock.call(ssh_dir, mode=0o700, uid=pw_uid, gid=pw_gid, mkdir=True),
         mock.call(authorized_keys_file, mode=0o600, uid=pw_uid, gid=pw_gid),
     ]
@@ -340,7 +339,6 @@ class AccountsUtilsTest(unittest.TestCase):
     self.assertEqual(mock_tempfile.mock_calls, expected_calls)
     mock_copy.assert_called_once_with(temp_dest, authorized_keys_file)
     expected_calls = [
-        mock.call(pw_dir, mode=0o750, uid=pw_uid, gid=pw_gid, mkdir=True),
         mock.call(ssh_dir, mode=0o700, uid=pw_uid, gid=pw_gid, mkdir=True),
         mock.call(authorized_keys_file, mode=0o600, uid=pw_uid, gid=pw_gid),
     ]


### PR DESCRIPTION
By default useradd should use the UMASK to set home directory file
permissions. SELinux context should also be set correctly by default.