### PR TITLE
Update "user_ssh_keys" when a user is removed.

### DIFF
--- a/google_compute_engine/accounts/accounts_daemon.py
+++ b/google_compute_engine/accounts/accounts_daemon.py
@@ -196,6 +196,7 @@ class AccountsDaemon(object):
     """
     for username in remove_users:
       self.utils.RemoveUser(username)
+      self.user_ssh_keys.pop(username, None)
     self.invalid_users -= set(remove_users)
 
   def HandleAccounts(self, result):

--- a/google_compute_engine/accounts/tests/accounts_daemon_test.py
+++ b/google_compute_engine/accounts/tests/accounts_daemon_test.py
@@ -293,6 +293,12 @@ class AccountsDaemonTest(unittest.TestCase):
 
   def testRemoveUsers(self):
     remove_users = ['a', 'b', 'c', 'valid']
+    self.mock_setup.user_ssh_keys = {
+        'a': ['1'],
+        'b': ['2'],
+        'c': ['3'],
+        'invalid': ['key'],
+    }
     self.mock_setup.invalid_users = set(['invalid', 'a', 'b', 'c'])
     accounts_daemon.AccountsDaemon._RemoveUsers(self.mock_setup, remove_users)
     expected_calls = [
@@ -303,6 +309,7 @@ class AccountsDaemonTest(unittest.TestCase):
     ]
     self.mock_utils.RemoveUser.assert_has_calls(expected_calls)
     self.assertEqual(self.mock_setup.invalid_users, set(['invalid']))
+    self.assertEqual(self.mock_setup.user_ssh_keys, {'invalid': ['key']})
 
   def testHandleAccounts(self):
     configured = ['c', 'c', 'b', 'b', 'a', 'a']


### PR DESCRIPTION
Currently, setting "block-project-ssh-keys" in instance metadata will
prevent all project ssh-keys from working. When a user unsets the
property, the project level keys will not start working again. This will
correct the behavior.