### PR TITLE
Remove travis testing against pypy3, add 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
 - 3.3
 - 3.4
 - 3.5
+- 3.6
 - pypy
-- pypy3
 os:
 - linux
 install:


### PR DESCRIPTION
pypy3 runs against Python 3.2 which is no longer supported. When we find
a way to install the latest version of pypy3 (which runs against python
3.5) we can add testing for it back.