### PR TITLE
allow other paths for nologin

### DIFF
--- a/google_compute_engine/accounts/accounts_utils.py
+++ b/google_compute_engine/accounts/accounts_utils.py
@@ -295,8 +295,8 @@ class AccountsUtils(object):
     # logins. This helps avoid problems caused by operator and root sharing
     # a home directory in CentOS and RHEL.
     pw_entry = self._GetUser(user)
-    if pw_entry and pw_entry.pw_shell == '/sbin/nologin':
-      message = 'Not updating user %s. User set /sbin/nologin as login shell.'
+    if pw_entry and os.path.basename(pw_entry.pw_shell) == 'nologin':
+      message = 'Not updating user %s. User set `nologin` as login shell.'
       self.logger.debug(message, user)
       return True
 


### PR DESCRIPTION
Hi,

I am integrating these tools to the NixOS GCE image (see https://github.com/NixOS/nixpkgs/pull/26214) and this is one of the patches required to make it work. I also had to patch a couple of hard-coded binary paths. Other than that it was pretty easy to integrate. Dynamic SSH keys, disks and metadata startup/shutdown scripts are all working. I haven't tested the IP forwarding.

Going forwards I am interested to see how we could collaborate to keep the NixOS integration working with new features.

Best,
z