### PR TITLE
Return 0 from AuthorizedKeys for non-oslogin users.

### DIFF
--- a/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
+++ b/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
@@ -40,7 +40,9 @@ int main(int argc, char* argv[]) {
   url << kMetadataServerUrl << "users?username=" << UrlEncode(argv[1]);
   string user_response = HttpGet(url.str());
   if (user_response.empty()) {
-    return 1;
+    // Return 0 if the user is not an oslogin user. If we returned a failure
+    // code, we would populate auth.log with useless error messages.
+    return 0;
   }
   string email = ParseJsonToEmail(user_response);
   if (email == "") {


### PR DESCRIPTION
Returning 1 just pollutes auth.log with unnecessary failure messages.