### PR TITLE
Minor code cleanup

### DIFF
--- a/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
+++ b/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
@@ -23,13 +23,11 @@ using std::endl;
 using std::string;
 
 using oslogin_utils::HttpGet;
+using oslogin_utils::kMetadataServerUrl;
 using oslogin_utils::UrlEncode;
 using oslogin_utils::ParseJsonToAuthorizeResponse;
 using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::ParseJsonToSshKeys;
-
-static const char kMetadataServerUrl[] =
-    "http://metadata.google.internal/computeMetadata/v1/oslogin/";
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {

--- a/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
+++ b/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
@@ -23,11 +23,11 @@ using std::endl;
 using std::string;
 
 using oslogin_utils::HttpGet;
-using oslogin_utils::kMetadataServerUrl;
-using oslogin_utils::UrlEncode;
 using oslogin_utils::ParseJsonToAuthorizeResponse;
 using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::ParseJsonToSshKeys;
+using oslogin_utils::UrlEncode;
+using oslogin_utils::kMetadataServerUrl;
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {

--- a/google_compute_engine_oslogin/nss_module/nss_oslogin.cc
+++ b/google_compute_engine_oslogin/nss_module/nss_oslogin.cc
@@ -32,11 +32,11 @@ using std::string;
 
 using oslogin_utils::BufferManager;
 using oslogin_utils::HttpGet;
-using oslogin_utils::kMetadataServerUrl;
 using oslogin_utils::MutexLock;
 using oslogin_utils::NssCache;
 using oslogin_utils::ParseJsonToPasswd;
 using oslogin_utils::UrlEncode;
+using oslogin_utils::kMetadataServerUrl;
 
 // Size of the NssCache. This also determines how many users will be requested
 // per HTTP call.
@@ -62,7 +62,7 @@ int _nss_oslogin_getpwuid_r(uid_t uid, struct passwd *result, char *buffer,
     return NSS_STATUS_NOTFOUND;
   }
   if (!ParseJsonToPasswd(response, result, &buffer_manager, errnop)) {
-    if(*errnop == EINVAL) {
+    if (*errnop == EINVAL) {
       openlog("nss_oslogin", LOG_PID, LOG_USER);
       syslog(LOG_ERR, "Received malformed response from server: %s",
              response.c_str());

--- a/google_compute_engine_oslogin/nss_module/nss_oslogin.cc
+++ b/google_compute_engine_oslogin/nss_module/nss_oslogin.cc
@@ -32,14 +32,11 @@ using std::string;
 
 using oslogin_utils::BufferManager;
 using oslogin_utils::HttpGet;
+using oslogin_utils::kMetadataServerUrl;
 using oslogin_utils::MutexLock;
 using oslogin_utils::NssCache;
 using oslogin_utils::ParseJsonToPasswd;
 using oslogin_utils::UrlEncode;
-
-// Metadata server URL.
-static const char kMetadataServerUrl[] =
-   "http://metadata.google.internal/computeMetadata/v1/oslogin/";
 
 // Size of the NssCache. This also determines how many users will be requested
 // per HTTP call.

--- a/google_compute_engine_oslogin/pam_module/pam_oslogin_admin.cc
+++ b/google_compute_engine_oslogin/pam_module/pam_oslogin_admin.cc
@@ -31,10 +31,10 @@
 using std::string;
 
 using oslogin_utils::HttpGet;
-using oslogin_utils::kMetadataServerUrl;
-using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::ParseJsonToAuthorizeResponse;
+using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::UrlEncode;
+using oslogin_utils::kMetadataServerUrl;
 
 static const char kSudoersDir[] = "/etc/google-sudoers.d/";
 

--- a/google_compute_engine_oslogin/pam_module/pam_oslogin_admin.cc
+++ b/google_compute_engine_oslogin/pam_module/pam_oslogin_admin.cc
@@ -31,12 +31,10 @@
 using std::string;
 
 using oslogin_utils::HttpGet;
+using oslogin_utils::kMetadataServerUrl;
 using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::ParseJsonToAuthorizeResponse;
 using oslogin_utils::UrlEncode;
-
-static const char kMetadataServerUrl[] =
-    "http://metadata.google.internal/computeMetadata/v1/oslogin/";
 
 static const char kSudoersDir[] = "/etc/google-sudoers.d/";
 

--- a/google_compute_engine_oslogin/pam_module/pam_oslogin_login.cc
+++ b/google_compute_engine_oslogin/pam_module/pam_oslogin_login.cc
@@ -30,10 +30,10 @@
 using std::string;
 
 using oslogin_utils::HttpGet;
-using oslogin_utils::kMetadataServerUrl;
-using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::ParseJsonToAuthorizeResponse;
+using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::UrlEncode;
+using oslogin_utils::kMetadataServerUrl;
 
 extern "C" {
 

--- a/google_compute_engine_oslogin/pam_module/pam_oslogin_login.cc
+++ b/google_compute_engine_oslogin/pam_module/pam_oslogin_login.cc
@@ -30,12 +30,10 @@
 using std::string;
 
 using oslogin_utils::HttpGet;
+using oslogin_utils::kMetadataServerUrl;
 using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::ParseJsonToAuthorizeResponse;
 using oslogin_utils::UrlEncode;
-
-static const char kMetadataServerUrl[] =
-    "http://metadata.google.internal/computeMetadata/v1/oslogin/";
 
 extern "C" {
 

--- a/google_compute_engine_oslogin/utils/oslogin_utils.h
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.h
@@ -26,7 +26,6 @@ namespace oslogin_utils {
 static const char kMetadataServerUrl[] =
    "http://metadata.google.internal/computeMetadata/v1/oslogin/";
 
-
 // BufferManager encapsulates and manages a buffer and length. This class is not
 // thread safe.
 class BufferManager {

--- a/google_compute_engine_oslogin/utils/oslogin_utils.h
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.h
@@ -22,6 +22,11 @@ using std::vector;
 
 namespace oslogin_utils {
 
+// Metadata server URL.
+static const char kMetadataServerUrl[] =
+   "http://metadata.google.internal/computeMetadata/v1/oslogin/";
+
+
 // BufferManager encapsulates and manages a buffer and length. This class is not
 // thread safe.
 class BufferManager {

--- a/google_compute_engine_oslogin/utils/oslogin_utils_test.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils_test.cc
@@ -54,7 +54,8 @@ TEST(BufferManagerTest, TestAppendStringTooLarge) {
   char* first_string;
   int test_errno = 0;
   oslogin_utils::BufferManager buffer_manager(buffer, buflen);
-  ASSERT_FALSE(buffer_manager.AppendString("test1", &first_string, &test_errno));
+  ASSERT_FALSE(
+      buffer_manager.AppendString("test1", &first_string, &test_errno));
   EXPECT_EQ(test_errno, ERANGE);
 }
 


### PR DESCRIPTION
This PR includes 2 minor changes.

1. Move definition of kMetadataServerUrl to oslogin_utils.h so it isn't defined in multiple places.
2. Some formatting/style consistency changes.