### PR TITLE
Reenable testing against pypy3 with pypy3-3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 sudo: true
 python:
@@ -8,6 +9,7 @@ python:
 - 3.5
 - 3.6
 - pypy
+- pypy3
 os:
 - linux
 install:


### PR DESCRIPTION
- [x] This is contingent on https://github.com/travis-ci/travis-cookbooks/pull/861.