### PR TITLE
Permit public https gs files as normal download

### DIFF
--- a/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/google_compute_engine/metadata_scripts/script_retriever.py
@@ -135,10 +135,8 @@ class ScriptRetriever(object):
     match = gs_regex.match(url)
     if match:
       gs_url = r'gs://%s/%s' % (match.group('bucket'), match.group('obj'))
-      dest = self._DownloadGsUrl(gs_url, dest_dir)
       # In case gsutil is not installed, continue as a normal URL
-      if dest is not None:
-        return dest
+      return self._DownloadGsUrl(gs_url, dest_dir) or self._DownloadUrl(url, dest_dir)
 
     # Check for the other possible Google Storage URLs:
     # http://storage.googleapis.com/<bucket>/<object>
@@ -152,10 +150,8 @@ class ScriptRetriever(object):
     match = gs_regex.match(url)
     if match:
       gs_url = r'gs://%s/%s' % (match.group('bucket'), match.group('obj'))
-      dest = self._DownloadGsUrl(gs_url, dest_dir)
       # In case gsutil is not installed, continue as a normal URL
-      if dest is not None:
-        return dest
+      return self._DownloadGsUrl(gs_url, dest_dir) or self._DownloadUrl(url, dest_dir)
 
     # Unauthenticated download of the object.
     return self._DownloadUrl(url, dest_dir)

--- a/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/google_compute_engine/metadata_scripts/script_retriever.py
@@ -135,7 +135,7 @@ class ScriptRetriever(object):
     match = gs_regex.match(url)
     if match:
       gs_url = r'gs://%s/%s' % (match.group('bucket'), match.group('obj'))
-      # In case gsutil is not installed, continue as a normal URL
+      # In case gsutil is not installed, continue as a normal URL.
       return (self._DownloadGsUrl(gs_url, dest_dir) or
               self._DownloadUrl(url, dest_dir))
 
@@ -151,7 +151,7 @@ class ScriptRetriever(object):
     match = gs_regex.match(url)
     if match:
       gs_url = r'gs://%s/%s' % (match.group('bucket'), match.group('obj'))
-      # In case gsutil is not installed, continue as a normal URL
+      # In case gsutil is not installed, continue as a normal URL.
       return (self._DownloadGsUrl(gs_url, dest_dir) or
               self._DownloadUrl(url, dest_dir))
 

--- a/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/google_compute_engine/metadata_scripts/script_retriever.py
@@ -135,7 +135,10 @@ class ScriptRetriever(object):
     match = gs_regex.match(url)
     if match:
       gs_url = r'gs://%s/%s' % (match.group('bucket'), match.group('obj'))
-      return self._DownloadGsUrl(gs_url, dest_dir)
+      dest = self._DownloadGsUrl(gs_url, dest_dir)
+      # In case gsutil is not installed, continue as a normal URL
+      if dest is not None:
+        return dest
 
     # Check for the other possible Google Storage URLs:
     # http://storage.googleapis.com/<bucket>/<object>
@@ -149,7 +152,10 @@ class ScriptRetriever(object):
     match = gs_regex.match(url)
     if match:
       gs_url = r'gs://%s/%s' % (match.group('bucket'), match.group('obj'))
-      return self._DownloadGsUrl(gs_url, dest_dir)
+      dest = self._DownloadGsUrl(gs_url, dest_dir)
+      # In case gsutil is not installed, continue as a normal URL
+      if dest is not None:
+        return dest
 
     # Unauthenticated download of the object.
     return self._DownloadUrl(url, dest_dir)

--- a/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/google_compute_engine/metadata_scripts/script_retriever.py
@@ -136,7 +136,8 @@ class ScriptRetriever(object):
     if match:
       gs_url = r'gs://%s/%s' % (match.group('bucket'), match.group('obj'))
       # In case gsutil is not installed, continue as a normal URL
-      return self._DownloadGsUrl(gs_url, dest_dir) or self._DownloadUrl(url, dest_dir)
+      return (self._DownloadGsUrl(gs_url, dest_dir) or
+              self._DownloadUrl(url, dest_dir))
 
     # Check for the other possible Google Storage URLs:
     # http://storage.googleapis.com/<bucket>/<object>
@@ -151,7 +152,8 @@ class ScriptRetriever(object):
     if match:
       gs_url = r'gs://%s/%s' % (match.group('bucket'), match.group('obj'))
       # In case gsutil is not installed, continue as a normal URL
-      return self._DownloadGsUrl(gs_url, dest_dir) or self._DownloadUrl(url, dest_dir)
+      return (self._DownloadGsUrl(gs_url, dest_dir) or
+              self._DownloadUrl(url, dest_dir))
 
     # Unauthenticated download of the object.
     return self._DownloadUrl(url, dest_dir)

--- a/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
+++ b/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
@@ -44,21 +44,6 @@ class ScriptRetrieverTest(unittest.TestCase):
 
   @mock.patch('google_compute_engine.metadata_scripts.script_retriever.subprocess.check_call')
   @mock.patch('google_compute_engine.metadata_scripts.script_retriever.tempfile.NamedTemporaryFile')
-  def testDownloadGsUrlFallback(self, mock_tempfile, mock_call):
-    mock_call.side_effect = subprocess.CalledProcessError('foo', 'bar')
-    gs_url = 'http://storage.googleapis.com/bucket/obj'
-    mock_tempfile.return_value = mock_tempfile
-    mock_tempfile.name = self.dest
-    self.assertEqual(
-        self.retriever._DownloadScript(gs_url, self.dest_dir), self.dest)
-    mock_call.assert_called_once_with(
-        ['which', 'gsutil'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    self.mock_logger.warning.assert_called_once_with(mock.ANY)
-    mock_tempfile.assert_called_once_with(dir=self.dest_dir, delete=False)
-    mock_tempfile.close.assert_called_once_with()
-
-  @mock.patch('google_compute_engine.metadata_scripts.script_retriever.subprocess.check_call')
-  @mock.patch('google_compute_engine.metadata_scripts.script_retriever.tempfile.NamedTemporaryFile')
   def testDownloadGsUrl(self, mock_tempfile, mock_call):
     gs_url = 'gs://fake/url'
     mock_tempfile.return_value = mock_tempfile

--- a/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
+++ b/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
@@ -44,6 +44,21 @@ class ScriptRetrieverTest(unittest.TestCase):
 
   @mock.patch('google_compute_engine.metadata_scripts.script_retriever.subprocess.check_call')
   @mock.patch('google_compute_engine.metadata_scripts.script_retriever.tempfile.NamedTemporaryFile')
+  def testDownloadGsUrlFallback(self, mock_tempfile, mock_call):
+    mock_call.side_effect = subprocess.CalledProcessError('foo', 'bar')
+    gs_url = 'http://storage.googleapis.com/bucket/obj'
+    mock_tempfile.return_value = mock_tempfile
+    mock_tempfile.name = self.dest
+    self.assertEqual(
+        self.retriever._DownloadScript(gs_url, self.dest_dir), self.dest)
+    mock_call.assert_called_once_with(
+        ['which', 'gsutil'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    self.mock_logger.warning.assert_called_once_with(mock.ANY)
+    mock_tempfile.assert_called_once_with(dir=self.dest_dir, delete=False)
+    mock_tempfile.close.assert_called_once_with()
+
+  @mock.patch('google_compute_engine.metadata_scripts.script_retriever.subprocess.check_call')
+  @mock.patch('google_compute_engine.metadata_scripts.script_retriever.tempfile.NamedTemporaryFile')
   def testDownloadGsUrl(self, mock_tempfile, mock_call):
     gs_url = 'gs://fake/url'
     mock_tempfile.return_value = mock_tempfile


### PR DESCRIPTION
COS (Container-Optimized OS from Google) doesn't comes pre-installed with `gsutil`.

If you try to setup `startup-script-url` metadata using Google Storage public link url (eg: `https://storage.googleapis/<bucket>/<object>`), it will fail: 

```terminal
myuser@some-instance-d8bw ~ $ sudo google_metadata_script_runner -d --script-type=startup
startup-script: INFO Starting startup scripts.
startup-script: INFO Found startup-script-url in metadata.
startup-script: WARNING gsutil is not installed, cannot download items from Google Storage.
startup-script: INFO No startup scripts found in metadata.
startup-script: INFO Finished running startup scripts.
```

The thing is: I had to dig a bit deeper to find this. But, my startup script is publicly available on Google Storage, and it only failed because it didn't attempt with usual `_DownloadUrl` fetching.

This patch allows for all users from Google Container optimized-OS to use `startup-script-url` stored on google storage.