### PR TITLE
Replace file paths by variables

### DIFF
--- a/google_compute_engine/accounts/accounts_daemon.py
+++ b/google_compute_engine/accounts/accounts_daemon.py
@@ -22,12 +22,13 @@ import optparse
 import random
 
 from google_compute_engine import config_manager
+from google_compute_engine import constants
 from google_compute_engine import file_utils
 from google_compute_engine import logger
 from google_compute_engine import metadata_watcher
 from google_compute_engine.accounts import accounts_utils
 
-LOCKFILE = '/var/lock/google_accounts.lock'
+LOCKFILE = constants.LOCALSTATEDIR + '/lock/google_accounts.lock'
 
 
 class AccountsDaemon(object):

--- a/google_compute_engine/accounts/accounts_utils.py
+++ b/google_compute_engine/accounts/accounts_utils.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import tempfile
 
+from google_compute_engine import constants
 from google_compute_engine import file_utils
 
 USER_REGEX = re.compile(r'\A[A-Za-z0-9._][A-Za-z0-9._-]*\Z')
@@ -43,8 +44,9 @@ class AccountsUtils(object):
     """
     self.logger = logger
     self.google_sudoers_group = 'google-sudoers'
-    self.google_sudoers_file = '/etc/sudoers.d/google_sudoers'
-    self.google_users_dir = '/var/lib/google'
+    self.google_sudoers_file = (
+        constants.LOCALBASE + '/etc/sudoers.d/google_sudoers')
+    self.google_users_dir = constants.LOCALBASE + '/var/lib/google'
     self.google_users_file = os.path.join(self.google_users_dir, 'google_users')
 
     self._CreateSudoersGroup()

--- a/google_compute_engine/boto/boto_config.py
+++ b/google_compute_engine/boto/boto_config.py
@@ -27,6 +27,7 @@ packaging.
 import os
 
 from google_compute_engine import config_manager
+from google_compute_engine import constants
 from google_compute_engine import logger
 from google_compute_engine import metadata_watcher
 
@@ -34,8 +35,8 @@ from google_compute_engine import metadata_watcher
 class BotoConfig(object):
   """Creates a boto config file for standalone GSUtil."""
 
-  boto_config = '/etc/boto.cfg'
-  boto_config_template = '/etc/boto.cfg.template'
+  boto_config = constants.BOTOCONFDIR + '/etc/boto.cfg'
+  boto_config_template = constants.BOTOCONFDIR + '/etc/boto.cfg.template'
   boto_config_script = os.path.abspath(__file__)
   boto_config_header = (
       'This file is automatically created at boot time by the %s script. Do '

--- a/google_compute_engine/clock_skew/clock_skew_daemon.py
+++ b/google_compute_engine/clock_skew/clock_skew_daemon.py
@@ -20,11 +20,12 @@ import optparse
 import subprocess
 
 from google_compute_engine import config_manager
+from google_compute_engine import constants
 from google_compute_engine import file_utils
 from google_compute_engine import logger
 from google_compute_engine import metadata_watcher
 
-LOCKFILE = '/var/lock/google_clock_skew.lock'
+LOCKFILE = constants.LOCALSTATEDIR + '/lock/google_clock_skew.lock'
 
 
 class ClockSkewDaemon(object):

--- a/google_compute_engine/config_manager.py
+++ b/google_compute_engine/config_manager.py
@@ -18,10 +18,11 @@
 import os
 import textwrap
 
+from google_compute_engine import constants
 from google_compute_engine import file_utils
 from google_compute_engine.compat import parser
 
-CONFIG = '/etc/default/instance_configs.cfg'
+CONFIG = constants.SYSCONFDIR + '/instance_configs.cfg'
 
 
 class ConfigManager(object):
@@ -101,7 +102,8 @@ class ConfigManager(object):
     """
     config_file = config_file or self.config_file
     config_name = os.path.splitext(os.path.basename(config_file))[0]
-    config_lock = '/var/lock/google_%s.lock' % config_name
+    config_lock = (
+        '%s/lock/google_%s.lock' % (constants.LOCALSTATEDIR, config_name))
     with file_utils.LockFile(config_lock):
       with open(config_file, 'w') as config_fp:
         if self.config_header:

--- a/google_compute_engine/constants.py
+++ b/google_compute_engine/constants.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A module for global constants."""
+
+import platform
+
+if platform.system() == 'FreeBSD':
+    LOCALBASE = '/usr/local'
+    BOTOCONFDIR = '/usr/local'
+    SYSCONFDIR = '/usr/local/etc'
+    LOCALSTATEDIR = '/var/spool'
+elif platform.system() == 'OpenBSD':
+    LOCALBASE = '/usr/local'
+    BOTOCONFDIR = ''
+    SYSCONFDIR = '/usr/local/etc'
+    LOCALSTATEDIR = '/var/spool'
+else:
+    LOCALBASE = ''
+    BOTOCONFDIR = ''
+    SYSCONFDIR = '/etc/default'
+    LOCALSTATEDIR = '/var'

--- a/google_compute_engine/instance_setup/instance_config.py
+++ b/google_compute_engine/instance_setup/instance_config.py
@@ -25,6 +25,7 @@ import logging
 import os
 
 from google_compute_engine import config_manager
+from google_compute_engine import constants
 from google_compute_engine.compat import parser
 from google_compute_engine.compat import stringio
 
@@ -32,7 +33,7 @@ from google_compute_engine.compat import stringio
 class InstanceConfig(config_manager.ConfigManager):
   """Creates a defaults config file for instance configuration."""
 
-  instance_config = '/etc/default/instance_configs.cfg'
+  instance_config = constants.SYSCONFDIR + '/instance_configs.cfg'
   instance_config_distro = '%s.distro' % instance_config
   instance_config_template = '%s.template' % instance_config
   instance_config_script = os.path.abspath(__file__)

--- a/google_compute_engine/instance_setup/instance_setup.py
+++ b/google_compute_engine/instance_setup/instance_setup.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import tempfile
 
+from google_compute_engine import constants
 from google_compute_engine import file_utils
 from google_compute_engine import logger
 from google_compute_engine import metadata_watcher
@@ -143,7 +144,7 @@ class InstanceSetup(object):
     """Initialize the SSH daemon."""
     # Exit as early as possible.
     # Instance setup systemd scripts block sshd from starting.
-    if os.path.exists('/bin/systemctl'):
+    if os.path.exists(constants.LOCALBASE + '/bin/systemctl'):
       return
     elif (os.path.exists('/etc/init.d/ssh') or
           os.path.exists('/etc/init/ssh.conf')):

--- a/google_compute_engine/ip_forwarding/ip_forwarding_daemon.py
+++ b/google_compute_engine/ip_forwarding/ip_forwarding_daemon.py
@@ -31,6 +31,7 @@ import optparse
 import random
 
 from google_compute_engine import config_manager
+from google_compute_engine import constants
 from google_compute_engine import file_utils
 from google_compute_engine import logger
 from google_compute_engine import metadata_watcher
@@ -38,7 +39,7 @@ from google_compute_engine import network_utils
 
 from google_compute_engine.ip_forwarding import ip_forwarding_utils
 
-LOCKFILE = '/var/lock/google_ip_forwarding.lock'
+LOCKFILE = constants.LOCALSTATEDIR + '/lock/google_ip_forwarding.lock'
 
 
 class IpForwardingDaemon(object):

--- a/google_compute_engine/metadata_scripts/script_executor.py
+++ b/google_compute_engine/metadata_scripts/script_executor.py
@@ -19,6 +19,8 @@ import os
 import stat
 import subprocess
 
+from google_compute_engine import constants
+
 
 class ScriptExecutor(object):
   """A class for executing user provided metadata scripts."""
@@ -50,7 +52,8 @@ class ScriptExecutor(object):
       metadata_script: string, the file location of an executable script.
     """
     process = subprocess.Popen(
-        metadata_script, shell=True, executable='/bin/bash',
+        metadata_script, shell=True,
+        executable=constants.LOCALBASE + '/bin/bash',
         stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
     while True:
       for line in iter(process.stdout.readline, b''):

--- a/google_compute_engine/network_setup/network_setup.py
+++ b/google_compute_engine/network_setup/network_setup.py
@@ -23,6 +23,7 @@ import re
 import subprocess
 
 from google_compute_engine import config_manager
+from google_compute_engine import constants
 from google_compute_engine import logger
 from google_compute_engine import metadata_watcher
 from google_compute_engine import network_utils
@@ -32,6 +33,7 @@ class NetworkSetup(object):
   """Enable network interfaces specified by metadata."""
 
   network_interfaces = 'instance/network-interfaces'
+  network_path = constants.LOCALBASE + '/etc/sysconfig/network-scripts'
 
   def __init__(self, dhclient_script=None, dhcp_command=None, debug=False):
     """Constructor.
@@ -74,9 +76,8 @@ class NetworkSetup(object):
     Args:
       interfaces: list of string, the output device names enable.
     """
-    interface_path = '/etc/sysconfig/network-scripts'
     for interface in interfaces:
-      interface_config = os.path.join(interface_path, 'ifcfg-%s' % interface)
+      interface_config = os.path.join(self.network_path, 'ifcfg-%s' % interface)
       if os.path.exists(interface_config):
         self._ModifyInterface(
             interface_config, 'DEVICE', interface, replace=False)
@@ -130,7 +131,7 @@ class NetworkSetup(object):
       except subprocess.CalledProcessError:
         self.logger.warning('Could not enable Ethernet interfaces.')
     else:
-      if os.path.exists('/etc/sysconfig/network-scripts'):
+      if os.path.exists(self.network_path):
         self._DisableNetworkManager(interfaces)
       self._ConfigureNetwork(interfaces)
 

--- a/google_compute_engine/network_setup/tests/network_setup_test.py
+++ b/google_compute_engine/network_setup/tests/network_setup_test.py
@@ -43,6 +43,7 @@ class NetworkSetupTest(unittest.TestCase):
     self.mock_setup.watcher = self.mock_watcher
     self.mock_setup.network_utils = self.mock_network_utils
     self.mock_setup.network_interfaces = self.metadata_key
+    self.mock_setup.network_path = '/etc/sysconfig/network-scripts'
     self.mock_setup.dhclient_script = '/bin/script'
     self.mock_setup.dhcp_command = ''
 


### PR DESCRIPTION
Paths can vary depending on the system. Instead of using the full path
in the code, use variables containing the correct path according to the
system. This will decrease the amount of patches required for FreeBSD,
OpenBSD, etc. and also will make the package easier to maintain across
different systems.