### PR TITLE
Update the control file to support EL 6 installs.

### DIFF
--- a/google_compute_engine_oslogin/bin/google_oslogin_control
+++ b/google_compute_engine_oslogin/bin/google_oslogin_control
@@ -97,19 +97,22 @@ restart_service() {
       systemctl restart ${service}
       return $?
     fi
-  elif which service > /dev/null 2>&1; then
+  fi
+  if which service > /dev/null 2>&1; then
     if service --status-all | grep -Fq ${service}; then
       echo "Restarting ${service}."
       service ${service} restart
       return $?
     fi
-  elif which invoke-rc.d > /dev/null 2>&1; then
+  fi
+  if which invoke-rc.d > /dev/null 2>&1; then
     if invoke-rc.d ${service} status > /dev/null 2>&1; then
       echo "Restarting ${service}."
       invoke-rc.d ${service} restart
       return $?
     fi
-  elif which /etc/init.d/${service} > /dev/null 2>&1; then
+  fi
+  if which /etc/init.d/${service} > /dev/null 2>&1; then
     if /etc/init.d/${service} status > /dev/null 2>&1; then
       echo "Restarting ${service}."
       /etc/init.d/${service} restart


### PR DESCRIPTION
On EL 6, service is present, but doesn't return the expected output.
Instead of failing to restart the service, try to use a different
supported mechanism.