### PR TITLE
Add instance config options for user/group commands.

### DIFF
--- a/google_compute_engine/accounts/accounts_daemon.py
+++ b/google_compute_engine/accounts/accounts_daemon.py
@@ -37,12 +37,18 @@ class AccountsDaemon(object):
   invalid_users = set()
   user_ssh_keys = {}
 
-  def __init__(self, groups=None, remove=False, debug=False):
+  def __init__(
+      self, groups=None, remove=False, useradd_cmd=None, userdel_cmd=None,
+      usermod_cmd=None, groupadd_cmd=None, debug=False):
     """Constructor.
 
     Args:
       groups: string, a comma separated list of groups.
       remove: bool, True if deprovisioning a user should be destructive.
+      useradd_cmd: string, command to create a new user.
+      userdel_cmd: string, command to delete a user.
+      usermod_cmd: string, command to modify user's groups.
+      groupadd_cmd: string, command to add a new group.
       debug: bool, True if debug output should write to the console.
     """
     facility = logging.handlers.SysLogHandler.LOG_DAEMON
@@ -50,7 +56,9 @@ class AccountsDaemon(object):
         name='google-accounts', debug=debug, facility=facility)
     self.watcher = metadata_watcher.MetadataWatcher(logger=self.logger)
     self.utils = accounts_utils.AccountsUtils(
-        logger=self.logger, groups=groups, remove=remove)
+        logger=self.logger, groups=groups, remove=remove,
+        useradd_cmd=useradd_cmd, userdel_cmd=userdel_cmd,
+        usermod_cmd=usermod_cmd, groupadd_cmd=groupadd_cmd)
     try:
       with file_utils.LockFile(LOCKFILE):
         self.logger.info('Starting Google Accounts daemon.')
@@ -226,6 +234,10 @@ def main():
     AccountsDaemon(
         groups=instance_config.GetOptionString('Accounts', 'groups'),
         remove=instance_config.GetOptionBool('Accounts', 'deprovision_remove'),
+        useradd_cmd=instance_config.GetOptionBool('Accounts', 'useradd_cmd'),
+        userdel_cmd=instance_config.GetOptionBool('Accounts', 'userdel_cmd'),
+        usermod_cmd=instance_config.GetOptionBool('Accounts', 'usermod_cmd'),
+        groupadd_cmd=instance_config.GetOptionBool('Accounts', 'groupadd_cmd'),
         debug=bool(options.debug))
 
 

--- a/google_compute_engine/accounts/accounts_utils.py
+++ b/google_compute_engine/accounts/accounts_utils.py
@@ -27,6 +27,10 @@ from google_compute_engine import constants
 from google_compute_engine import file_utils
 
 USER_REGEX = re.compile(r'\A[A-Za-z0-9._][A-Za-z0-9._-]*\Z')
+DEFAULT_USERADD_CMD = 'useradd -m -s /bin/bash -p * {user}'
+DEFAULT_USERDEL_CMD = 'userdel -r {user}'
+DEFAULT_USERMOD_CMD = 'groupadd {group}'
+DEFAULT_GROUPADD_CMD = 'groupadd {group}'
 
 
 class AccountsUtils(object):
@@ -34,14 +38,24 @@ class AccountsUtils(object):
 
   google_comment = '# Added by Google'
 
-  def __init__(self, logger, groups=None, remove=False):
+  def __init__(
+      self, logger, groups=None, remove=False, useradd_cmd=None,
+      userdel_cmd=None, usermod_cmd=None, groupadd_cmd=None):
     """Constructor.
 
     Args:
       logger: logger object, used to write to SysLog and serial port.
       groups: string, a comma separated list of groups.
       remove: bool, True if deprovisioning a user should be destructive.
+      useradd_cmd: string, command to create a new user.
+      userdel_cmd: string, command to delete a user.
+      usermod_cmd: string, command to modify user's groups.
+      groupadd_cmd: string, command to add a new group.
     """
+    self.useradd_cmd = useradd_cmd or DEFAULT_USERADD_CMD
+    self.userdel_cmd = userdel_cmd or DEFAULT_USERDEL_CMD
+    self.usermod_cmd = usermod_cmd or DEFAULT_USERMOD_CMD
+    self.groupadd_cmd = groupadd_cmd or DEFAULT_GROUPADD_CMD
     self.logger = logger
     self.google_sudoers_group = 'google-sudoers'
     self.google_sudoers_file = (
@@ -73,7 +87,9 @@ class AccountsUtils(object):
     """Create a Linux group for Google added sudo user accounts."""
     if not self._GetGroup(self.google_sudoers_group):
       try:
-        subprocess.check_call(['groupadd', self.google_sudoers_group])
+        subprocess.check_call(
+            self.groupadd_cmd.format(group=self.google_sudoers_group),
+            shell=True)
       except subprocess.CalledProcessError as e:
         self.logger.warning('Could not create the sudoers group. %s.', str(e))
 
@@ -117,20 +133,9 @@ class AccountsUtils(object):
     """
     self.logger.info('Creating a new user account for %s.', user)
 
-    # The encrypted password is set to '*' for SSH on Linux systems
-    # without PAM.
-    #
-    # SSH uses '!' as its locked account token:
-    # https://github.com/openssh/openssh-portable/blob/master/configure.ac
-    #
-    # When the token is specified, SSH denies login:
-    # https://github.com/openssh/openssh-portable/blob/master/auth.c
-    #
-    # To solve the issue, make the password '*' which is also recognized
-    # as locked but does not prevent SSH login.
-    command = ['useradd', '-m', '-s', '/bin/bash', '-p', '*', user]
+    command = self.useradd_cmd.format(user=user)
     try:
-      subprocess.check_call(command)
+      subprocess.check_call(command, shell=True)
     except subprocess.CalledProcessError as e:
       self.logger.warning('Could not create user %s. %s.', user, str(e))
       return False
@@ -150,9 +155,9 @@ class AccountsUtils(object):
     """
     groups = ','.join(groups)
     self.logger.debug('Updating user %s with groups %s.', user, groups)
-    command = ['usermod', '-G', groups, user]
+    command = self.usermod_cmd.format(user=user, groups=groups)
     try:
-      subprocess.check_call(command)
+      subprocess.check_call(command, shell=True)
     except subprocess.CalledProcessError as e:
       self.logger.warning('Could not update user %s. %s.', user, str(e))
       return False
@@ -319,9 +324,9 @@ class AccountsUtils(object):
     """
     self.logger.info('Removing user %s.', user)
     if self.remove:
-      command = ['userdel', '-r', user]
+      command = self.userdel_cmd.format(user=user)
       try:
-        subprocess.check_call(command)
+        subprocess.check_call(command, shell=True)
       except subprocess.CalledProcessError as e:
         self.logger.warning('Could not remove user %s. %s.', user, str(e))
       else:

--- a/google_compute_engine/accounts/tests/accounts_daemon_test.py
+++ b/google_compute_engine/accounts/tests/accounts_daemon_test.py
@@ -54,7 +54,9 @@ class AccountsDaemonTest(unittest.TestCase):
           mock.call.logger.Logger(name=mock.ANY, debug=True, facility=mock.ANY),
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.AccountsUtils(
-              logger=mock_logger_instance, groups='foo,bar', remove=True),
+              logger=mock_logger_instance, groups='foo,bar', remove=True,
+              useradd_cmd=mock.ANY, userdel_cmd=mock.ANY, usermod_cmd=mock.ANY,
+              groupadd_cmd=mock.ANY),
           mock.call.lock.LockFile(accounts_daemon.LOCKFILE),
           mock.call.lock.LockFile().__enter__(),
           mock.call.logger.Logger().info(mock.ANY),
@@ -85,7 +87,9 @@ class AccountsDaemonTest(unittest.TestCase):
               name=mock.ANY, debug=False, facility=mock.ANY),
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.AccountsUtils(
-              logger=mock_logger_instance, groups=None, remove=False),
+              logger=mock_logger_instance, groups=None, remove=False,
+              useradd_cmd=mock.ANY, userdel_cmd=mock.ANY, usermod_cmd=mock.ANY,
+              groupadd_cmd=mock.ANY),
           mock.call.lock.LockFile(accounts_daemon.LOCKFILE),
           mock.call.logger.Logger().warning('Test Error'),
       ]

--- a/google_compute_engine/instance_setup/instance_config.py
+++ b/google_compute_engine/instance_setup/instance_config.py
@@ -46,6 +46,22 @@ class InstanceConfig(config_manager.ConfigManager):
       'Accounts': {
           'deprovision_remove': 'false',
           'groups': 'adm,dip,docker,lxd,plugdev,video',
+
+          # The encrypted password is set to '*' for SSH on Linux systems
+          # without PAM.
+          #
+          # SSH uses '!' as its locked account token:
+          # https://github.com/openssh/openssh-portable/blob/master/configure.ac
+          #
+          # When the token is specified, SSH denies login:
+          # https://github.com/openssh/openssh-portable/blob/master/auth.c
+          #
+          # To solve the issue, make the password '*' which is also recognized
+          # as locked but does not prevent SSH login.
+          'useradd_cmd': 'useradd -m -s /bin/bash -p * {user}',
+          'userdel_cmd': 'userdel -r {user}',
+          'usermod_cmd': 'groupadd {group}',
+          'groupadd_cmd': 'usermod -G {groups} {user}',
       },
       'Daemons': {
           'accounts_daemon': 'true',


### PR DESCRIPTION
Command to manage users and groups can vary according to the system.
Thus move this commands to the port.py for interoperability with BSD

The content of constants.py was moved to port.py, as it won't contain only constants variables, the file name is no more appropriated
