### PR TITLE
Add local files to track os-login users in the event of a transient failure.

### DIFF
--- a/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
+++ b/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
@@ -37,13 +37,16 @@ int main(int argc, char* argv[]) {
   std::stringstream url;
   url << kMetadataServerUrl << "users?username=" << UrlEncode(argv[1]);
   string user_response;
-  if (!HttpGet(url.str(), &user_response)) {
+  long http_code = 0;
+  if (!HttpGet(url.str(), &user_response, &http_code)) {
     return 1;
   }
-  if (user_response.empty()) {
+  if (http_code == 404) {
     // Return 0 if the user is not an oslogin user. If we returned a failure
     // code, we would populate auth.log with useless error messages.
     return 0;
+  } else if (user_response.empty() || http_code == 500) {
+    return 1;
   }
   string email = ParseJsonToEmail(user_response);
   if (email.empty()) {
@@ -58,7 +61,8 @@ int main(int argc, char* argv[]) {
   url << kMetadataServerUrl << "authorize?email=" << UrlEncode(email)
       << "&policy=login";
   string auth_response;
-  if (!HttpGet(url.str(), &auth_response) || auth_response.empty()) {
+  if (!HttpGet(url.str(), &auth_response, &http_code) || http_code > 400 ||
+      auth_response.empty()) {
     return 1;
   }
   if (!ParseJsonToAuthorizeResponse(auth_response)) {

--- a/google_compute_engine_oslogin/bin/google_oslogin_control
+++ b/google_compute_engine_oslogin/bin/google_oslogin_control
@@ -19,6 +19,7 @@ pam_config="/etc/pam.d/sshd"
 sshd_config="/etc/ssh/sshd_config"
 el_release_file="/etc/redhat-release"
 sudoers_dir="/var/google-sudoers.d"
+users_dir="/var/google-users.d"
 sudoers_file="/etc/sudoers.d/google-oslogin"
 
 usage() {
@@ -179,6 +180,15 @@ deactivate_sudoers() {
   rm -rf ${sudoers_dir}
 }
 
+activate_users() {
+  mkdir -p ${users_dir}
+  chmod 750 ${users_dir}
+}
+
+deactivate_users() {
+  rm -f ${users_dir}
+  rm -rf ${users_dir}
+}
 case "$1" in
   activate)
     echo "Activating Google Compute Engine OS Login."
@@ -186,6 +196,7 @@ case "$1" in
     activate_nss
     activate_pam
     activate_sudoers
+    activate_users
     ;;
   deactivate)
     echo "Deactivating Google Compute Engine OS Login."
@@ -193,6 +204,7 @@ case "$1" in
     deactivate_nss
     deactivate_pam
     deactivate_sudoers
+    deactivate_users
     ;;
   *)
     usage

--- a/google_compute_engine_oslogin/nss_module/nss_oslogin.cc
+++ b/google_compute_engine_oslogin/nss_module/nss_oslogin.cc
@@ -57,7 +57,9 @@ int _nss_oslogin_getpwuid_r(uid_t uid, struct passwd *result, char *buffer,
   std::stringstream url;
   url << kMetadataServerUrl << "users?uid=" << uid;
   string response;
-  if (!HttpGet(url.str(), &response) || response.empty()) {
+  long http_code = 0;
+  if (!HttpGet(url.str(), &response, &http_code) || http_code >= 400 ||
+      response.empty()) {
     *errnop = ENOENT;
     return NSS_STATUS_NOTFOUND;
   }
@@ -80,7 +82,9 @@ int _nss_oslogin_getpwnam_r(const char *name, struct passwd *result,
   std::stringstream url;
   url << kMetadataServerUrl << "users?username=" << UrlEncode(name);
   string response;
-  if (!HttpGet(url.str(), &response) || response.empty()) {
+  long http_code = 0;
+  if (!HttpGet(url.str(), &response, &http_code) || http_code >= 400 ||
+      response.empty()) {
     *errnop = ENOENT;
     return NSS_STATUS_NOTFOUND;
   }
@@ -125,7 +129,9 @@ int _nss_oslogin_getpwent_r(struct passwd *result, char *buffer, size_t buflen,
       url << "&pagetoken=" << page_token;
     }
     string response;
-    if (!HttpGet(url.str(), &response) || response.empty()) {
+    long http_code = 0;
+    if (!HttpGet(url.str(), &response, &http_code) || http_code >= 400 ||
+        response.empty()) {
       *errnop = ENOENT;
       return NSS_STATUS_NOTFOUND;
     }

--- a/google_compute_engine_oslogin/utils/oslogin_utils.h
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.h
@@ -128,8 +128,8 @@ OnCurlWrite(void* buf, size_t size, size_t nmemb, void* userp);
 
 // Uses Curl to issue a GET request to the given url. Returns whether the
 // request was successful. If successful, the result from the server will be
-// stored in response.
-bool HttpGet(const string& url, string* response);
+// stored in response, and the HTTP response code will be stored in http_code.
+bool HttpGet(const string& url, string* response, long* http_code);
 
 // URL encodes the given parameter. Returns the encoded parameter.
 std::string UrlEncode(const string& param);


### PR DESCRIPTION
Adds a local file when an os-login user successfully logs in. If a server error occurs, we will check if this file exists to deny os-login users, and permit local users.

Additionally, clean up HttpGet() to set an http response code to better respond to server errors.