### PR TITLE
Version bump the OS Login and Python packages.

### DIFF
--- a/google_compute_engine_oslogin/Makefile
+++ b/google_compute_engine_oslogin/Makefile
@@ -4,7 +4,7 @@ BASENAME = oslogin
 NAME = google-compute-engine-$(BASENAME)
 MAJOR = 1
 MINOR = 0
-REVISION = 1
+REVISION = 2
 
 NSS_LIBRARY_NAME = libnss_$(NAME)-$(MAJOR).$(MINOR).$(REVISION).so
 NSS_LIBRARY_SONAME = libnss_$(BASENAME).so.2

--- a/google_compute_engine_oslogin/packaging/debian8/changelog
+++ b/google_compute_engine_oslogin/packaging/debian8/changelog
@@ -1,3 +1,9 @@
+google-compute-engine-oslogin (1.0.2-1+deb8) unstable; urgency=low
+
+  * Improve security in case of transient errors.
+
+ -- MAINTAINER <gc-team@google.com>  Tue, 15 Aug 2017 12:00:00 -0700
+
 google-compute-engine-oslogin (1.0.1-1+deb8) unstable; urgency=low
 
   * Fix for restarting sshd and nscd.

--- a/google_compute_engine_oslogin/packaging/debian8/google-compute-engine-oslogin.links
+++ b/google_compute_engine_oslogin/packaging/debian8/google-compute-engine-oslogin.links
@@ -1,1 +1,1 @@
-/lib/libnss_google-compute-engine-oslogin-1.0.1.so /lib/libnss_oslogin.so.2
+/lib/libnss_google-compute-engine-oslogin-1.0.2.so /lib/libnss_oslogin.so.2

--- a/google_compute_engine_oslogin/packaging/debian9/changelog
+++ b/google_compute_engine_oslogin/packaging/debian9/changelog
@@ -1,3 +1,9 @@
+google-compute-engine-oslogin (1.0.2-1+deb9) unstable; urgency=low
+
+  * Improve security in case of transient errors.
+
+ -- MAINTAINER <gc-team@google.com>  Tue, 15 Aug 2017 12:00:00 -0700
+
 google-compute-engine-oslogin (1.0.1-1+deb9) unstable; urgency=low
 
   * Fix for restarting sshd and nscd.

--- a/google_compute_engine_oslogin/packaging/debian9/google-compute-engine-oslogin.links
+++ b/google_compute_engine_oslogin/packaging/debian9/google-compute-engine-oslogin.links
@@ -1,1 +1,1 @@
-/lib/libnss_google-compute-engine-oslogin-1.0.1.so /lib/libnss_oslogin.so.2
+/lib/libnss_google-compute-engine-oslogin-1.0.2.so /lib/libnss_oslogin.so.2

--- a/google_compute_engine_oslogin/packaging/rpmbuild/SPECS/google-compute-engine-oslogin.spec
+++ b/google_compute_engine_oslogin/packaging/rpmbuild/SPECS/google-compute-engine-oslogin.spec
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 Name:           google-compute-engine-oslogin
-Version:        1.0.1
+Version:        1.0.2
 Release:        1%{?dist}
 Summary:        OS Login Functionality for Google Compute Engine
 

--- a/google_compute_engine_oslogin/packaging/setup_deb.sh
+++ b/google_compute_engine_oslogin/packaging/setup_deb.sh
@@ -20,7 +20,7 @@
 
 # Run from the top of the source directory.
 NAME="google-compute-engine-oslogin"
-VERSION="1.0.1"
+VERSION="1.0.2"
 
 working_dir=${PWD}
 

--- a/google_compute_engine_oslogin/packaging/setup_rpm.sh
+++ b/google_compute_engine_oslogin/packaging/setup_rpm.sh
@@ -20,7 +20,7 @@
 
 # Run from the top of the source directory.
 NAME="google-compute-engine-oslogin"
-VERSION="1.0.1"
+VERSION="1.0.2"
 
 working_dir=${PWD}
 rpm_working_dir=/tmp/rpmpackage/${NAME}-${VERSION}

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     scripts=glob.glob('scripts/*'),
     url='https://github.com/GoogleCloudPlatform/compute-image-packages',
-    version='2.4.1',
+    version='2.5.0',
     # Entry points create scripts in /usr/bin that call a function.
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
google-compute-engine version bump to 2.5.0.
google-compute-engine-oslogin version bump to 1.0.2.