### PR TITLE
Strictly check for HTTP code 200.

### DIFF
--- a/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
+++ b/google_compute_engine_oslogin/authorized_keys/authorized_keys.cc
@@ -38,14 +38,13 @@ int main(int argc, char* argv[]) {
   url << kMetadataServerUrl << "users?username=" << UrlEncode(argv[1]);
   string user_response;
   long http_code = 0;
-  if (!HttpGet(url.str(), &user_response, &http_code)) {
-    return 1;
-  }
-  if (http_code == 404) {
-    // Return 0 if the user is not an oslogin user. If we returned a failure
-    // code, we would populate auth.log with useless error messages.
-    return 0;
-  } else if (user_response.empty() || http_code == 500) {
+  if (!HttpGet(url.str(), &user_response, &http_code) ||
+      user_response.empty() || http_code != 200) {
+    if (http_code == 404) {
+      // Return 0 if the user is not an oslogin user. If we returned a failure
+      // code, we would populate auth.log with useless error messages.
+      return 0;
+    }
     return 1;
   }
   string email = ParseJsonToEmail(user_response);
@@ -61,7 +60,7 @@ int main(int argc, char* argv[]) {
   url << kMetadataServerUrl << "authorize?email=" << UrlEncode(email)
       << "&policy=login";
   string auth_response;
-  if (!HttpGet(url.str(), &auth_response, &http_code) || http_code > 400 ||
+  if (!HttpGet(url.str(), &auth_response, &http_code) || http_code != 200 ||
       auth_response.empty()) {
     return 1;
   }

--- a/google_compute_engine_oslogin/nss_module/nss_oslogin.cc
+++ b/google_compute_engine_oslogin/nss_module/nss_oslogin.cc
@@ -58,7 +58,7 @@ int _nss_oslogin_getpwuid_r(uid_t uid, struct passwd *result, char *buffer,
   url << kMetadataServerUrl << "users?uid=" << uid;
   string response;
   long http_code = 0;
-  if (!HttpGet(url.str(), &response, &http_code) || http_code >= 400 ||
+  if (!HttpGet(url.str(), &response, &http_code) || http_code != 200 ||
       response.empty()) {
     *errnop = ENOENT;
     return NSS_STATUS_NOTFOUND;
@@ -83,7 +83,7 @@ int _nss_oslogin_getpwnam_r(const char *name, struct passwd *result,
   url << kMetadataServerUrl << "users?username=" << UrlEncode(name);
   string response;
   long http_code = 0;
-  if (!HttpGet(url.str(), &response, &http_code) || http_code >= 400 ||
+  if (!HttpGet(url.str(), &response, &http_code) || http_code != 200 ||
       response.empty()) {
     *errnop = ENOENT;
     return NSS_STATUS_NOTFOUND;
@@ -130,7 +130,7 @@ int _nss_oslogin_getpwent_r(struct passwd *result, char *buffer, size_t buflen,
     }
     string response;
     long http_code = 0;
-    if (!HttpGet(url.str(), &response, &http_code) || http_code >= 400 ||
+    if (!HttpGet(url.str(), &response, &http_code) || http_code != 200 ||
         response.empty()) {
       *errnop = ENOENT;
       return NSS_STATUS_NOTFOUND;

--- a/google_compute_engine_oslogin/pam_module/pam_oslogin_admin.cc
+++ b/google_compute_engine_oslogin/pam_module/pam_oslogin_admin.cc
@@ -57,7 +57,7 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc,
       << "users?username=" << UrlEncode(str_user_name);
   string response;
   long http_code = 0;
-  if (!HttpGet(url.str(), &response, &http_code) || http_code >= 400 ||
+  if (!HttpGet(url.str(), &response, &http_code) || http_code != 200 ||
       response.empty()) {
     return PAM_SUCCESS;
   }


### PR DESCRIPTION
In many cases, we really should only proceed if we get http code 200.

This changes several of the checks to only accept 200. The only exception is in pam_oslogin_login.cc, which cares specifically about server failures.