### PR TITLE
Fix system hang when shutown

### DIFF
--- a/google_compute_engine_init/systemd/google-shutdown-scripts.service
+++ b/google_compute_engine_init/systemd/google-shutdown-scripts.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Google Compute Engine Shutdown Scripts
-After=local-fs.target network-online.target network.target rsyslog.service
+After=local-fs.target network-online.target network.target rsyslog.service systemd-resolved.service
 After=google-instance-setup.service google-network-setup.service
 Wants=local-fs.target network-online.target network.target
 


### PR DESCRIPTION
Existing systemd shtudown script would cause system hang by waiting for DNS response but system-resolved service may be down.

Ref: #480