### PR TITLE
Modify ParseJsonToPasswd to properly parse uids and gids as uint32s

### DIFF
--- a/google_compute_engine_oslogin/utils/oslogin_utils.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.cc
@@ -342,13 +342,13 @@ bool ParseJsonToPasswd(string response, struct passwd* result,
         *errnop = EINVAL;
         return false;
       }
-      result->pw_uid = (int)json_object_get_int(val);
+      result->pw_uid = (uint32_t)json_object_get_int64(val);
     } else if (string_key == "gid") {
       if (val_type != json_type_int) {
         *errnop = EINVAL;
         return false;
       }
-      result->pw_gid = (int)json_object_get_int(val);
+      result->pw_gid = (uint32_t)json_object_get_int64(val);
     } else if (string_key == "username") {
       if (val_type != json_type_string) {
         *errnop = EINVAL;


### PR DESCRIPTION
This fixes a bug where a uid > 2^31 was parsed as an int32 and consequently truncated to 2^31.