### PR TITLE
Remove broken/redundant rm command from control script.

### DIFF
--- a/google_compute_engine_oslogin/bin/google_oslogin_control
+++ b/google_compute_engine_oslogin/bin/google_oslogin_control
@@ -186,7 +186,6 @@ activate_users() {
 }
 
 deactivate_users() {
-  rm -f ${users_dir}
   rm -rf ${users_dir}
 }
 case "$1" in


### PR DESCRIPTION
Removes broken/redundant rm command from control script.