### PR TITLE
Added udev rules to symlink nvme devices into the disk/by-id/ directory

### DIFF
--- a/google_config/udev/65-gce-disk-naming.rules
+++ b/google_config/udev/65-gce-disk-naming.rules
@@ -20,5 +20,7 @@ SUBSYSTEM!="block", GOTO="gce_disk_naming_end"
 KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
 KERNEL=="sd*|vd*", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"
 KERNEL=="sd*|vd*", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="partition", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}-part%n"
+KERNEL=="nvme*", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-%k"
+KERNEL=="nvme*", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="partition", SYMLINK+="disk/by-id/google-%k"
 
 LABEL="gce_disk_naming_end"


### PR DESCRIPTION
Fixes #485 

We need to be able to access nvme devices by unique id in the disk/by-id directory. I'm not that familiar with udev rules so please take a close look at this.

cc @msau42 