### PR TITLE
OS Login activation/deactivation

### DIFF
--- a/google_compute_engine/accounts/accounts_daemon.py
+++ b/google_compute_engine/accounts/accounts_daemon.py
@@ -177,7 +177,7 @@ class AccountsDaemon(object):
       project_data = {}
       self.logger.warning('Project attributes were not found.')
 
-      return instance_data, project_data
+    return instance_data, project_data
 
   def _GetAccountsData(self, metadata_dict):
     """Get the user accounts specified in metadata server contents.
@@ -234,13 +234,13 @@ class AccountsDaemon(object):
     Returns:
       bool, True if OS Login is enabled for VM access.
     """
-    instance_data, project_data = self.GetInstanceAndProjectAttributes(
+    instance_data, project_data = self._GetInstanceAndProjectAttributes(
         metadata_dict)
     instance_value = instance_data.get('enable-oslogin')
     project_value = project_data.get('enable-oslogin')
-    value = instance_value or project_value
+    value = instance_value or project_value or ''
 
-    return lower(value) == 'true'
+    return value.lower() == 'true'
 
   def HandleAccounts(self, result):
     """Called when there are changes to the contents of the metadata server.
@@ -252,7 +252,7 @@ class AccountsDaemon(object):
     configured_users = self.utils.GetConfiguredUsers()
     enable_oslogin = self._GetEnableOsLoginValue(result)
     if enable_oslogin:
-      desired_users = []
+      desired_users = {}
       self.oslogin.UpdateOsLogin(enable=True)
     else:
       desired_users = self._GetAccountsData(result)

--- a/google_compute_engine/accounts/accounts_daemon.py
+++ b/google_compute_engine/accounts/accounts_daemon.py
@@ -59,6 +59,8 @@ class AccountsDaemon(object):
         logger=self.logger, groups=groups, remove=remove,
         useradd_cmd=useradd_cmd, userdel_cmd=userdel_cmd,
         usermod_cmd=usermod_cmd, groupadd_cmd=groupadd_cmd)
+    self.oslogin = oslogin_utils.OsLoginUtils(logger=self.logger)
+
     try:
       with file_utils.LockFile(LOCKFILE):
         self.logger.info('Starting Google Accounts daemon.')
@@ -151,14 +153,14 @@ class AccountsDaemon(object):
     logging.debug('User accounts: %s.', user_map)
     return user_map
 
-  def _GetAccountsData(self, metadata_dict):
-    """Get the user accounts specified in metadata server contents.
+  def _GetInstanceAndProjectAttributes(self, metadata_dict):
+    """Get dictionaries for instance and project attributes.
 
     Args:
       metadata_dict: json, the deserialized contents of the metadata server.
 
     Returns:
-      dict, a mapping of the form: {'username': ['sshkey1, 'sshkey2', ...]}.
+      tuple, two dictionaries for instance and project attributes.
     """
     metadata_dict = metadata_dict or {}
 
@@ -173,6 +175,20 @@ class AccountsDaemon(object):
     except KeyError:
       project_data = {}
       self.logger.warning('Project attributes were not found.')
+
+      return instance_data, project_data
+
+  def _GetAccountsData(self, metadata_dict):
+    """Get the user accounts specified in metadata server contents.
+
+    Args:
+      metadata_dict: json, the deserialized contents of the metadata server.
+
+    Returns:
+      dict, a mapping of the form: {'username': ['sshkey1, 'sshkey2', ...]}.
+    """
+    instance_data, project_data = self._GetInstanceAndProjectAttributes(
+        metadata_dict)
     valid_keys = [instance_data.get('sshKeys'), instance_data.get('ssh-keys')]
     block_project = instance_data.get('block-project-ssh-keys', '').lower()
     if block_project != 'true' and not instance_data.get('sshKeys'):
@@ -208,6 +224,16 @@ class AccountsDaemon(object):
       self.user_ssh_keys.pop(username, None)
     self.invalid_users -= set(remove_users)
 
+  def _GetEnableOsLoginValue(self, metadata_dict):
+    """Get the value of the enable-oslogin metadata key."""
+    instance_data, project_data = self.GetInstanceAndProjectAttributes(
+        metadata_dict)
+    instance_value = instance_data.get('enable-oslogin')
+    project_value = project_data.get('enable-oslogin')
+    value = instance_value or project_value
+
+    return lower(value) == 'true':
+
   def HandleAccounts(self, result):
     """Called when there are changes to the contents of the metadata server.
 
@@ -216,7 +242,13 @@ class AccountsDaemon(object):
     """
     self.logger.debug('Checking for changes to user accounts.')
     configured_users = self.utils.GetConfiguredUsers()
-    desired_users = self._GetAccountsData(result)
+    enable_oslogin = self._GetEnableOsLoginValue(result)
+    if enable_oslogin:
+      desired_users = []
+      self.oslogin.CheckOsLoginStatusAndUpdate(enable=True)
+    else:
+      desired_users = self._GetAccountsData(result)
+      self.oslogin.CheckOsLoginStatusAndUpdate(enable=False)
     remove_users = sorted(set(configured_users) - set(desired_users.keys()))
     self._UpdateUsers(desired_users)
     self._RemoveUsers(remove_users)

--- a/google_compute_engine/accounts/oslogin_utils.py
+++ b/google_compute_engine/accounts/oslogin_utils.py
@@ -1,0 +1,340 @@
+#!/usr/bin/python
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for provisioning or deprovisioning a Linux user account."""
+
+import grp
+import os
+import pwd
+import re
+import shutil
+import subprocess
+import tempfile
+
+from google_compute_engine import constants
+from google_compute_engine import file_utils
+
+USER_REGEX = re.compile(r'\A[A-Za-z0-9._][A-Za-z0-9._-]*\Z')
+DEFAULT_GROUPADD_CMD = 'groupadd {group}'
+DEFAULT_USERADD_CMD = 'useradd -m -s /bin/bash -p * {user}'
+DEFAULT_USERDEL_CMD = 'userdel -r {user}'
+DEFAULT_USERMOD_CMD = 'usermod -G {groups} {user}'
+
+
+class AccountsUtils(object):
+  """System user account configuration utilities."""
+
+  google_comment = '# Added by Google'
+
+  def __init__(
+      self, logger, groups=None, remove=False, groupadd_cmd=None,
+      useradd_cmd=None, userdel_cmd=None, usermod_cmd=None):
+    """Constructor.
+
+    Args:
+      logger: logger object, used to write to SysLog and serial port.
+      groups: string, a comma separated list of groups.
+      remove: bool, True if deprovisioning a user should be destructive.
+      groupadd_cmd: string, command to add a new group.
+      useradd_cmd: string, command to create a new user.
+      userdel_cmd: string, command to delete a user.
+      usermod_cmd: string, command to modify user's groups.
+    """
+    self.groupadd_cmd = groupadd_cmd or DEFAULT_GROUPADD_CMD
+    self.useradd_cmd = useradd_cmd or DEFAULT_USERADD_CMD
+    self.userdel_cmd = userdel_cmd or DEFAULT_USERDEL_CMD
+    self.usermod_cmd = usermod_cmd or DEFAULT_USERMOD_CMD
+    self.logger = logger
+    self.google_sudoers_group = 'google-sudoers'
+    self.google_sudoers_file = (
+        constants.LOCALBASE + '/etc/sudoers.d/google_sudoers')
+    self.google_users_dir = constants.LOCALBASE + '/var/lib/google'
+    self.google_users_file = os.path.join(self.google_users_dir, 'google_users')
+
+    self._CreateSudoersGroup()
+    self.groups = groups.split(',') if groups else []
+    self.groups.append(self.google_sudoers_group)
+    self.groups = list(filter(self._GetGroup, self.groups))
+    self.remove = remove
+
+  def _GetGroup(self, group):
+    """Retrieve a Linux group.
+
+    Args:
+      group: string, the name of the Linux group to retrieve.
+
+    Returns:
+      grp.struct_group, the Linux group or None if it does not exist.
+    """
+    try:
+      return grp.getgrnam(group)
+    except KeyError:
+      return None
+
+  def _CreateSudoersGroup(self):
+    """Create a Linux group for Google added sudo user accounts."""
+    if not self._GetGroup(self.google_sudoers_group):
+      try:
+        command = self.groupadd_cmd.format(group=self.google_sudoers_group)
+        subprocess.check_call(command.split(' '))
+      except subprocess.CalledProcessError as e:
+        self.logger.warning('Could not create the sudoers group. %s.', str(e))
+
+    if not os.path.exists(self.google_sudoers_file):
+      try:
+        with open(self.google_sudoers_file, 'w') as group:
+          message = '%{0} ALL=(ALL:ALL) NOPASSWD:ALL'.format(
+              self.google_sudoers_group)
+          group.write(message)
+      except IOError as e:
+        self.logger.error(
+            'Could not write sudoers file. %s. %s',
+            self.google_sudoers_file, str(e))
+        return
+
+    file_utils.SetPermissions(
+        self.google_sudoers_file, mode=0o440, uid=0, gid=0)
+
+  def _GetUser(self, user):
+    """Retrieve a Linux user account.
+
+    Args:
+      user: string, the name of the Linux user account to retrieve.
+
+    Returns:
+      pwd.struct_passwd, the Linux user or None if it does not exist.
+    """
+    try:
+      return pwd.getpwnam(user)
+    except KeyError:
+      return None
+
+  def _AddUser(self, user):
+    """Configure a Linux user account.
+
+    Args:
+      user: string, the name of the Linux user account to create.
+
+    Returns:
+      bool, True if user creation succeeded.
+    """
+    self.logger.info('Creating a new user account for %s.', user)
+
+    command = self.useradd_cmd.format(user=user)
+    try:
+      subprocess.check_call(command.split(' '))
+    except subprocess.CalledProcessError as e:
+      self.logger.warning('Could not create user %s. %s.', user, str(e))
+      return False
+    else:
+      self.logger.info('Created user account %s.', user)
+      return True
+
+  def _UpdateUserGroups(self, user, groups):
+    """Update group membership for a Linux user.
+
+    Args:
+      user: string, the name of the Linux user account.
+      groups: list, the group names to add the user as a member.
+
+    Returns:
+      bool, True if user update succeeded.
+    """
+    groups = ','.join(groups)
+    self.logger.debug('Updating user %s with groups %s.', user, groups)
+    command = self.usermod_cmd.format(user=user, groups=groups)
+    try:
+      subprocess.check_call(command.split(' '))
+    except subprocess.CalledProcessError as e:
+      self.logger.warning('Could not update user %s. %s.', user, str(e))
+      return False
+    else:
+      self.logger.debug('Updated user account %s.', user)
+      return True
+
+  def _UpdateAuthorizedKeys(self, user, ssh_keys):
+    """Update the authorized keys file for a Linux user with a list of SSH keys.
+
+    Args:
+      user: string, the name of the Linux user account.
+      ssh_keys: list, the SSH key strings associated with the user.
+
+    Raises:
+      IOError, raised when there is an exception updating a file.
+      OSError, raised when setting permissions or writing to a read-only
+          file system.
+    """
+    pw_entry = self._GetUser(user)
+    if not pw_entry:
+      return
+
+    uid = pw_entry.pw_uid
+    gid = pw_entry.pw_gid
+    home_dir = pw_entry.pw_dir
+    ssh_dir = os.path.join(home_dir, '.ssh')
+
+    # Not all sshd's support multiple authorized_keys files so we have to
+    # share one with the user. We add each of our entries as follows:
+    #  # Added by Google
+    #  authorized_key_entry
+    authorized_keys_file = os.path.join(ssh_dir, 'authorized_keys')
+
+    # Do not write to the authorized keys file if it is a symlink.
+    if os.path.islink(ssh_dir) or os.path.islink(authorized_keys_file):
+      self.logger.warning(
+          'Not updating authorized keys for user %s. File is a symlink.', user)
+      return
+
+    file_utils.SetPermissions(ssh_dir, mode=0o700, uid=uid, gid=gid, mkdir=True)
+
+    prefix = self.logger.name + '-'
+    with tempfile.NamedTemporaryFile(
+        mode='w', prefix=prefix, delete=True) as updated_keys:
+      updated_keys_file = updated_keys.name
+      if os.path.exists(authorized_keys_file):
+        lines = open(authorized_keys_file).readlines()
+      else:
+        lines = []
+
+      google_lines = set()
+      for i, line in enumerate(lines):
+        if line.startswith(self.google_comment):
+          google_lines.update([i, i+1])
+
+      # Write user's authorized key entries.
+      for i, line in enumerate(lines):
+        if i not in google_lines and line:
+          line += '\n' if not line.endswith('\n') else ''
+          updated_keys.write(line)
+
+      # Write the Google authorized key entries at the end of the file.
+      # Each entry is preceded by '# Added by Google'.
+      for ssh_key in ssh_keys:
+        ssh_key += '\n' if not ssh_key.endswith('\n') else ''
+        updated_keys.write('%s\n' % self.google_comment)
+        updated_keys.write(ssh_key)
+
+      # Write buffered data to the updated keys file without closing it and
+      # update the Linux user's authorized keys file.
+      updated_keys.flush()
+      shutil.copy(updated_keys_file, authorized_keys_file)
+
+    file_utils.SetPermissions(
+        authorized_keys_file, mode=0o600, uid=uid, gid=gid)
+
+  def _RemoveAuthorizedKeys(self, user):
+    """Remove a Linux user account's authorized keys file to prevent login.
+
+    Args:
+      user: string, the Linux user account to remove access.
+    """
+    pw_entry = self._GetUser(user)
+    if not pw_entry:
+      return
+
+    home_dir = pw_entry.pw_dir
+    authorized_keys_file = os.path.join(home_dir, '.ssh', 'authorized_keys')
+    if os.path.exists(authorized_keys_file):
+      try:
+        os.remove(authorized_keys_file)
+      except OSError as e:
+        message = 'Could not remove authorized keys for user %s. %s.'
+        self.logger.warning(message, user, str(e))
+
+  def GetConfiguredUsers(self):
+    """Retrieve the list of configured Google user accounts.
+
+    Returns:
+      list, the username strings of users congfigured by Google.
+    """
+    if os.path.exists(self.google_users_file):
+      users = open(self.google_users_file).readlines()
+    else:
+      users = []
+    return [user.strip() for user in users]
+
+  def SetConfiguredUsers(self, users):
+    """Set the list of configured Google user accounts.
+
+    Args:
+      users: list, the username strings of the Linux accounts.
+    """
+    prefix = self.logger.name + '-'
+    with tempfile.NamedTemporaryFile(
+        mode='w', prefix=prefix, delete=True) as updated_users:
+      updated_users_file = updated_users.name
+      for user in users:
+        updated_users.write(user + '\n')
+      updated_users.flush()
+      if not os.path.exists(self.google_users_dir):
+        os.makedirs(self.google_users_dir)
+      shutil.copy(updated_users_file, self.google_users_file)
+
+    file_utils.SetPermissions(self.google_users_file, mode=0o600, uid=0, gid=0)
+
+  def UpdateUser(self, user, ssh_keys):
+    """Update a Linux user with authorized SSH keys.
+
+    Args:
+      user: string, the name of the Linux user account.
+      ssh_keys: list, the SSH key strings associated with the user.
+
+    Returns:
+      bool, True if the user account updated successfully.
+    """
+    if not bool(USER_REGEX.match(user)):
+      self.logger.warning('Invalid user account name %s.', user)
+      return False
+    if not self._GetUser(user):
+      # User does not exist. Attempt to create the user and add them to the
+      # appropriate user groups.
+      if not (self._AddUser(user) and
+              self._UpdateUserGroups(user, self.groups)):
+        return False
+
+    # Don't try to manage account SSH keys with a shell set to disable
+    # logins. This helps avoid problems caused by operator and root sharing
+    # a home directory in CentOS and RHEL.
+    pw_entry = self._GetUser(user)
+    if pw_entry and os.path.basename(pw_entry.pw_shell) == 'nologin':
+      message = 'Not updating user %s. User set `nologin` as login shell.'
+      self.logger.debug(message, user)
+      return True
+
+    try:
+      self._UpdateAuthorizedKeys(user, ssh_keys)
+    except (IOError, OSError) as e:
+      message = 'Could not update the authorized keys file for user %s. %s.'
+      self.logger.warning(message, user, str(e))
+      return False
+    else:
+      return True
+
+  def RemoveUser(self, user):
+    """Remove a Linux user account.
+
+    Args:
+      user: string, the Linux user account to remove.
+    """
+    self.logger.info('Removing user %s.', user)
+    if self.remove:
+      command = self.userdel_cmd.format(user=user)
+      try:
+        subprocess.check_call(command.split(' '))
+      except subprocess.CalledProcessError as e:
+        self.logger.warning('Could not remove user %s. %s.', user, str(e))
+      else:
+        self.logger.info('Removed user account %s.', user)
+    self._RemoveAuthorizedKeys(user)

--- a/google_compute_engine/accounts/oslogin_utils.py
+++ b/google_compute_engine/accounts/oslogin_utils.py
@@ -37,8 +37,8 @@ class OsLoginUtils(object):
     """Run the OS Login control script.
 
     Args:
-      action: str, The action to pass to the script
-          (activate, deactivate or status).
+      action: str, the action to pass to the script
+          (activate, deactivate, or status).
 
     Returns:
       int, the return code from the call, or None if the script is not found.
@@ -71,7 +71,10 @@ class OsLoginUtils(object):
     """Check to see if OS Login is enabled, and switch if necessary.
 
     Args:
-      enable: bool, Enable OS Login if True, disable if False.
+      enable: bool, enable OS Login if True, disable if False.
+
+    Returns:
+      int, the return code from updating OS Login, or None if not present.
     """
     status = self._GetStatus()
     if status is None or status == enable:

--- a/google_compute_engine/accounts/oslogin_utils.py
+++ b/google_compute_engine/accounts/oslogin_utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,326 +15,66 @@
 
 """Utilities for provisioning or deprovisioning a Linux user account."""
 
-import grp
 import os
-import pwd
-import re
-import shutil
 import subprocess
-import tempfile
 
 from google_compute_engine import constants
-from google_compute_engine import file_utils
-
-USER_REGEX = re.compile(r'\A[A-Za-z0-9._][A-Za-z0-9._-]*\Z')
-DEFAULT_GROUPADD_CMD = 'groupadd {group}'
-DEFAULT_USERADD_CMD = 'useradd -m -s /bin/bash -p * {user}'
-DEFAULT_USERDEL_CMD = 'userdel -r {user}'
-DEFAULT_USERMOD_CMD = 'usermod -G {groups} {user}'
 
 
-class AccountsUtils(object):
-  """System user account configuration utilities."""
+class OsLoginUtils(object):
+  """Utilities for OS Login activation."""
 
-  google_comment = '# Added by Google'
-
-  def __init__(
-      self, logger, groups=None, remove=False, groupadd_cmd=None,
-      useradd_cmd=None, userdel_cmd=None, usermod_cmd=None):
+  def __init__(self, logger):
     """Constructor.
 
     Args:
       logger: logger object, used to write to SysLog and serial port.
-      groups: string, a comma separated list of groups.
-      remove: bool, True if deprovisioning a user should be destructive.
-      groupadd_cmd: string, command to add a new group.
-      useradd_cmd: string, command to create a new user.
-      userdel_cmd: string, command to delete a user.
-      usermod_cmd: string, command to modify user's groups.
     """
-    self.groupadd_cmd = groupadd_cmd or DEFAULT_GROUPADD_CMD
-    self.useradd_cmd = useradd_cmd or DEFAULT_USERADD_CMD
-    self.userdel_cmd = userdel_cmd or DEFAULT_USERDEL_CMD
-    self.usermod_cmd = usermod_cmd or DEFAULT_USERMOD_CMD
     self.logger = logger
-    self.google_sudoers_group = 'google-sudoers'
-    self.google_sudoers_file = (
-        constants.LOCALBASE + '/etc/sudoers.d/google_sudoers')
-    self.google_users_dir = constants.LOCALBASE + '/var/lib/google'
-    self.google_users_file = os.path.join(self.google_users_dir, 'google_users')
+    self.oslogin_installed = True
 
-    self._CreateSudoersGroup()
-    self.groups = groups.split(',') if groups else []
-    self.groups.append(self.google_sudoers_group)
-    self.groups = list(filter(self._GetGroup, self.groups))
-    self.remove = remove
-
-  def _GetGroup(self, group):
-    """Retrieve a Linux group.
+  def _RunOsLoginControl(self, action):
+    """Run the OS Login control script.
 
     Args:
-      group: string, the name of the Linux group to retrieve.
+      action: str, The action to pass to the script
+          (activate, deactivate or status)
 
     Returns:
-      grp.struct_group, the Linux group or None if it does not exist.
+      int, The return code from the call, or None if the script is not found.
     """
     try:
-      return grp.getgrnam(group)
-    except KeyError:
+      return subprocess.call([constants.OSLOGIN_CONTROL_SCRIPT, action])
+    except OSError as e:
+      if e.errno == os.errno.ENOENT:
+        return None
+      else:
+        raise
+
+  def _GetStatus(self):
+    retcode = self._RunOsLoginControl('status')
+    if retcode is None:
+      if self.oslogin_installed:
+        self.logger.warning('OS Login not installed.')
+        self.oslogin_installed = False
       return None
 
-  def _CreateSudoersGroup(self):
-    """Create a Linux group for Google added sudo user accounts."""
-    if not self._GetGroup(self.google_sudoers_group):
-      try:
-        command = self.groupadd_cmd.format(group=self.google_sudoers_group)
-        subprocess.check_call(command.split(' '))
-      except subprocess.CalledProcessError as e:
-        self.logger.warning('Could not create the sudoers group. %s.', str(e))
+    self.oslogin_installed = True
+    return not retcode
 
-    if not os.path.exists(self.google_sudoers_file):
-      try:
-        with open(self.google_sudoers_file, 'w') as group:
-          message = '%{0} ALL=(ALL:ALL) NOPASSWD:ALL'.format(
-              self.google_sudoers_group)
-          group.write(message)
-      except IOError as e:
-        self.logger.error(
-            'Could not write sudoers file. %s. %s',
-            self.google_sudoers_file, str(e))
-        return
-
-    file_utils.SetPermissions(
-        self.google_sudoers_file, mode=0o440, uid=0, gid=0)
-
-  def _GetUser(self, user):
-    """Retrieve a Linux user account.
+  def CheckOsLoginStatusAndUpdate(self, enable):
+    """Check to see if OS Login is enabled, and switch if necessary.
 
     Args:
-      user: string, the name of the Linux user account to retrieve.
-
-    Returns:
-      pwd.struct_passwd, the Linux user or None if it does not exist.
+      enable: bool, Enable OS Login if True, disable if False.
     """
-    try:
-      return pwd.getpwnam(user)
-    except KeyError:
+    status = self._GetStatus()
+    if (status is None) or (status == enable) :
       return None
 
-  def _AddUser(self, user):
-    """Configure a Linux user account.
-
-    Args:
-      user: string, the name of the Linux user account to create.
-
-    Returns:
-      bool, True if user creation succeeded.
-    """
-    self.logger.info('Creating a new user account for %s.', user)
-
-    command = self.useradd_cmd.format(user=user)
-    try:
-      subprocess.check_call(command.split(' '))
-    except subprocess.CalledProcessError as e:
-      self.logger.warning('Could not create user %s. %s.', user, str(e))
-      return False
+    if enable:
+      action = 'activate'
     else:
-      self.logger.info('Created user account %s.', user)
-      return True
+      action = 'deactivate'
 
-  def _UpdateUserGroups(self, user, groups):
-    """Update group membership for a Linux user.
-
-    Args:
-      user: string, the name of the Linux user account.
-      groups: list, the group names to add the user as a member.
-
-    Returns:
-      bool, True if user update succeeded.
-    """
-    groups = ','.join(groups)
-    self.logger.debug('Updating user %s with groups %s.', user, groups)
-    command = self.usermod_cmd.format(user=user, groups=groups)
-    try:
-      subprocess.check_call(command.split(' '))
-    except subprocess.CalledProcessError as e:
-      self.logger.warning('Could not update user %s. %s.', user, str(e))
-      return False
-    else:
-      self.logger.debug('Updated user account %s.', user)
-      return True
-
-  def _UpdateAuthorizedKeys(self, user, ssh_keys):
-    """Update the authorized keys file for a Linux user with a list of SSH keys.
-
-    Args:
-      user: string, the name of the Linux user account.
-      ssh_keys: list, the SSH key strings associated with the user.
-
-    Raises:
-      IOError, raised when there is an exception updating a file.
-      OSError, raised when setting permissions or writing to a read-only
-          file system.
-    """
-    pw_entry = self._GetUser(user)
-    if not pw_entry:
-      return
-
-    uid = pw_entry.pw_uid
-    gid = pw_entry.pw_gid
-    home_dir = pw_entry.pw_dir
-    ssh_dir = os.path.join(home_dir, '.ssh')
-
-    # Not all sshd's support multiple authorized_keys files so we have to
-    # share one with the user. We add each of our entries as follows:
-    #  # Added by Google
-    #  authorized_key_entry
-    authorized_keys_file = os.path.join(ssh_dir, 'authorized_keys')
-
-    # Do not write to the authorized keys file if it is a symlink.
-    if os.path.islink(ssh_dir) or os.path.islink(authorized_keys_file):
-      self.logger.warning(
-          'Not updating authorized keys for user %s. File is a symlink.', user)
-      return
-
-    file_utils.SetPermissions(ssh_dir, mode=0o700, uid=uid, gid=gid, mkdir=True)
-
-    prefix = self.logger.name + '-'
-    with tempfile.NamedTemporaryFile(
-        mode='w', prefix=prefix, delete=True) as updated_keys:
-      updated_keys_file = updated_keys.name
-      if os.path.exists(authorized_keys_file):
-        lines = open(authorized_keys_file).readlines()
-      else:
-        lines = []
-
-      google_lines = set()
-      for i, line in enumerate(lines):
-        if line.startswith(self.google_comment):
-          google_lines.update([i, i+1])
-
-      # Write user's authorized key entries.
-      for i, line in enumerate(lines):
-        if i not in google_lines and line:
-          line += '\n' if not line.endswith('\n') else ''
-          updated_keys.write(line)
-
-      # Write the Google authorized key entries at the end of the file.
-      # Each entry is preceded by '# Added by Google'.
-      for ssh_key in ssh_keys:
-        ssh_key += '\n' if not ssh_key.endswith('\n') else ''
-        updated_keys.write('%s\n' % self.google_comment)
-        updated_keys.write(ssh_key)
-
-      # Write buffered data to the updated keys file without closing it and
-      # update the Linux user's authorized keys file.
-      updated_keys.flush()
-      shutil.copy(updated_keys_file, authorized_keys_file)
-
-    file_utils.SetPermissions(
-        authorized_keys_file, mode=0o600, uid=uid, gid=gid)
-
-  def _RemoveAuthorizedKeys(self, user):
-    """Remove a Linux user account's authorized keys file to prevent login.
-
-    Args:
-      user: string, the Linux user account to remove access.
-    """
-    pw_entry = self._GetUser(user)
-    if not pw_entry:
-      return
-
-    home_dir = pw_entry.pw_dir
-    authorized_keys_file = os.path.join(home_dir, '.ssh', 'authorized_keys')
-    if os.path.exists(authorized_keys_file):
-      try:
-        os.remove(authorized_keys_file)
-      except OSError as e:
-        message = 'Could not remove authorized keys for user %s. %s.'
-        self.logger.warning(message, user, str(e))
-
-  def GetConfiguredUsers(self):
-    """Retrieve the list of configured Google user accounts.
-
-    Returns:
-      list, the username strings of users congfigured by Google.
-    """
-    if os.path.exists(self.google_users_file):
-      users = open(self.google_users_file).readlines()
-    else:
-      users = []
-    return [user.strip() for user in users]
-
-  def SetConfiguredUsers(self, users):
-    """Set the list of configured Google user accounts.
-
-    Args:
-      users: list, the username strings of the Linux accounts.
-    """
-    prefix = self.logger.name + '-'
-    with tempfile.NamedTemporaryFile(
-        mode='w', prefix=prefix, delete=True) as updated_users:
-      updated_users_file = updated_users.name
-      for user in users:
-        updated_users.write(user + '\n')
-      updated_users.flush()
-      if not os.path.exists(self.google_users_dir):
-        os.makedirs(self.google_users_dir)
-      shutil.copy(updated_users_file, self.google_users_file)
-
-    file_utils.SetPermissions(self.google_users_file, mode=0o600, uid=0, gid=0)
-
-  def UpdateUser(self, user, ssh_keys):
-    """Update a Linux user with authorized SSH keys.
-
-    Args:
-      user: string, the name of the Linux user account.
-      ssh_keys: list, the SSH key strings associated with the user.
-
-    Returns:
-      bool, True if the user account updated successfully.
-    """
-    if not bool(USER_REGEX.match(user)):
-      self.logger.warning('Invalid user account name %s.', user)
-      return False
-    if not self._GetUser(user):
-      # User does not exist. Attempt to create the user and add them to the
-      # appropriate user groups.
-      if not (self._AddUser(user) and
-              self._UpdateUserGroups(user, self.groups)):
-        return False
-
-    # Don't try to manage account SSH keys with a shell set to disable
-    # logins. This helps avoid problems caused by operator and root sharing
-    # a home directory in CentOS and RHEL.
-    pw_entry = self._GetUser(user)
-    if pw_entry and os.path.basename(pw_entry.pw_shell) == 'nologin':
-      message = 'Not updating user %s. User set `nologin` as login shell.'
-      self.logger.debug(message, user)
-      return True
-
-    try:
-      self._UpdateAuthorizedKeys(user, ssh_keys)
-    except (IOError, OSError) as e:
-      message = 'Could not update the authorized keys file for user %s. %s.'
-      self.logger.warning(message, user, str(e))
-      return False
-    else:
-      return True
-
-  def RemoveUser(self, user):
-    """Remove a Linux user account.
-
-    Args:
-      user: string, the Linux user account to remove.
-    """
-    self.logger.info('Removing user %s.', user)
-    if self.remove:
-      command = self.userdel_cmd.format(user=user)
-      try:
-        subprocess.check_call(command.split(' '))
-      except subprocess.CalledProcessError as e:
-        self.logger.warning('Could not remove user %s. %s.', user, str(e))
-      else:
-        self.logger.info('Removed user account %s.', user)
-    self._RemoveAuthorizedKeys(user)
+    return self._RunOsLoginControl(activate)

--- a/google_compute_engine/accounts/oslogin_utils.py
+++ b/google_compute_engine/accounts/oslogin_utils.py
@@ -55,7 +55,7 @@ class OsLoginUtils(object):
     """Check whether OS Login is installed.
 
     Returns:
-      bool, True if OS Login is installed
+      bool, True if OS Login is installed.
     """
     retcode = self._RunOsLoginControl('status')
     if retcode is None:
@@ -84,4 +84,4 @@ class OsLoginUtils(object):
       action = 'deactivate'
       self.logger.warning('Deactivating OS Login.')
 
-    return self._RunOsLoginControl(activate)
+    return self._RunOsLoginControl(action)

--- a/google_compute_engine/accounts/oslogin_utils.py
+++ b/google_compute_engine/accounts/oslogin_utils.py
@@ -38,10 +38,10 @@ class OsLoginUtils(object):
 
     Args:
       action: str, The action to pass to the script
-          (activate, deactivate or status)
+          (activate, deactivate or status).
 
     Returns:
-      int, The return code from the call, or None if the script is not found.
+      int, the return code from the call, or None if the script is not found.
     """
     try:
       return subprocess.call([constants.OSLOGIN_CONTROL_SCRIPT, action])
@@ -52,6 +52,11 @@ class OsLoginUtils(object):
         raise
 
   def _GetStatus(self):
+    """Check whether OS Login is installed.
+
+    Returns:
+      bool, True if OS Login is installed
+    """
     retcode = self._RunOsLoginControl('status')
     if retcode is None:
       if self.oslogin_installed:
@@ -62,19 +67,21 @@ class OsLoginUtils(object):
     self.oslogin_installed = True
     return not retcode
 
-  def CheckOsLoginStatusAndUpdate(self, enable):
+  def UpdateOsLogin(self, enable):
     """Check to see if OS Login is enabled, and switch if necessary.
 
     Args:
       enable: bool, Enable OS Login if True, disable if False.
     """
     status = self._GetStatus()
-    if (status is None) or (status == enable) :
+    if status is None or status == enable:
       return None
 
     if enable:
       action = 'activate'
+      self.logger.warning('Activating OS Login.')
     else:
       action = 'deactivate'
+      self.logger.warning('Deactivating OS Login.')
 
     return self._RunOsLoginControl(activate)

--- a/google_compute_engine/accounts/tests/accounts_daemon_test.py
+++ b/google_compute_engine/accounts/tests/accounts_daemon_test.py
@@ -36,7 +36,6 @@ class AccountsDaemonTest(unittest.TestCase):
     self.mock_setup.utils = self.mock_utils
     self.mock_setup.oslogin = self.mock_oslogin
 
-
   @mock.patch('google_compute_engine.accounts.accounts_daemon.accounts_utils')
   @mock.patch('google_compute_engine.accounts.accounts_daemon.metadata_watcher')
   @mock.patch('google_compute_engine.accounts.accounts_daemon.logger')
@@ -176,18 +175,19 @@ class AccountsDaemonTest(unittest.TestCase):
         data: dictionary, the faux metadata server contents.
         expected: list, the faux SSH keys expected to be set.
       """
-      self.assertEqual(accounts_daemon.AccountsDaemon._GetInstanceAndProjectAttributes(
-        self.mock_setup, data), expected)
+      self.assertEqual(
+          accounts_daemon.AccountsDaemon._GetInstanceAndProjectAttributes(
+              self.mock_setup, data), expected)
 
     data = None
-    _AssertAttributeDict(data, ({},{}))
+    _AssertAttributeDict(data, ({}, {}))
 
     data = {'test': 'data'}
-    expected = ({},{})
+    expected = ({}, {})
     _AssertAttributeDict(data, expected)
 
     data = {'instance': {'attributes': {}}}
-    expected = ({},{})
+    expected = ({}, {})
     _AssertAttributeDict(data, expected)
 
     data = {'instance': {'attributes': {'ssh-keys': '1'}}}
@@ -312,15 +312,15 @@ class AccountsDaemonTest(unittest.TestCase):
     _AssertAccountsData(data, ['1', '2'])
 
     data = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
-                {'ssh-keys': '2'})
+            {'ssh-keys': '2'})
     _AssertAccountsData(data, ['1', '2'])
 
     data = ({'block-project-ssh-keys': 'true', 'ssh-keys': '1'},
-                {'ssh-keys': '2'})
+            {'ssh-keys': '2'})
     _AssertAccountsData(data, ['1'])
 
     data = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
-                {'sshKeys': '3', 'ssh-keys': '2'})
+            {'sshKeys': '3', 'ssh-keys': '2'})
     _AssertAccountsData(data, ['1', '2', '3'])
 
   def testGetEnableOsLoginValue(self):
@@ -333,7 +333,8 @@ class AccountsDaemonTest(unittest.TestCase):
         expected: bool, if True, OS Login is enabled.
       """
       self.mock_setup._GetInstanceAndProjectAttributes.return_value = data
-      actual = accounts_daemon.AccountsDaemon._GetEnableOsLoginValue(self.mock_setup, data)
+      actual = accounts_daemon.AccountsDaemon._GetEnableOsLoginValue(
+          self.mock_setup, data)
       self.assertEqual(actual, expected)
 
     data = ({}, {})
@@ -379,7 +380,6 @@ class AccountsDaemonTest(unittest.TestCase):
     data = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
             {'sshKeys': '3', 'ssh-keys': '2', 'enable-oslogin': 'true'})
     _AssertEnableOsLogin(data, True)
-
 
   def testUpdateUsers(self):
     update_users = {

--- a/google_compute_engine/accounts/tests/accounts_daemon_test.py
+++ b/google_compute_engine/accounts/tests/accounts_daemon_test.py
@@ -28,11 +28,14 @@ class AccountsDaemonTest(unittest.TestCase):
     self.mock_logger = mock.Mock()
     self.mock_watcher = mock.Mock()
     self.mock_utils = mock.Mock()
+    self.mock_oslogin = mock.Mock()
 
     self.mock_setup = mock.create_autospec(accounts_daemon.AccountsDaemon)
     self.mock_setup.logger = self.mock_logger
     self.mock_setup.watcher = self.mock_watcher
     self.mock_setup.utils = self.mock_utils
+    self.mock_setup.oslogin = self.mock_oslogin
+
 
   @mock.patch('google_compute_engine.accounts.accounts_daemon.accounts_utils')
   @mock.patch('google_compute_engine.accounts.accounts_daemon.metadata_watcher')
@@ -164,44 +167,44 @@ class AccountsDaemonTest(unittest.TestCase):
     self.assertEqual(accounts_daemon.AccountsDaemon._ParseAccountsData(
         self.mock_setup, accounts_data), expected_users)
 
-  def testGetAccountsData(self):
+  def testGetInstanceAndProjectAttributes(self):
 
-    def _AssertAccountsData(data, expected):
+    def _AssertAttributeDict(data, expected):
       """Test the correct accounts data is returned.
 
       Args:
         data: dictionary, the faux metadata server contents.
         expected: list, the faux SSH keys expected to be set.
       """
-      accounts_daemon.AccountsDaemon._GetAccountsData(self.mock_setup, data)
-      if expected:
-        call_args, _ = self.mock_setup._ParseAccountsData.call_args
-        actual = call_args[0]
-        self.assertEqual(set(actual.split()), set(expected))
-      else:
-        self.mock_setup._ParseAccountsData.assert_called_once_with(expected)
-      self.mock_setup._ParseAccountsData.reset_mock()
+      self.assertEqual(accounts_daemon.AccountsDaemon._GetInstanceAndProjectAttributes(
+        self.mock_setup, data), expected)
 
     data = None
-    _AssertAccountsData(data, '')
+    _AssertAttributeDict(data, ({},{}))
 
     data = {'test': 'data'}
-    _AssertAccountsData(data, '')
+    expected = ({},{})
+    _AssertAttributeDict(data, expected)
 
     data = {'instance': {'attributes': {}}}
-    _AssertAccountsData(data, '')
+    expected = ({},{})
+    _AssertAttributeDict(data, expected)
 
     data = {'instance': {'attributes': {'ssh-keys': '1'}}}
-    _AssertAccountsData(data, ['1'])
+    expected = ({'ssh-keys': '1'}, {})
+    _AssertAttributeDict(data, expected)
 
     data = {'instance': {'attributes': {'ssh-keys': '1', 'sshKeys': '2'}}}
-    _AssertAccountsData(data, ['1', '2'])
+    expected = ({'ssh-keys': '1', 'sshKeys': '2'}, {})
+    _AssertAttributeDict(data, expected)
 
     data = {'project': {'attributes': {'ssh-keys': '1'}}}
-    _AssertAccountsData(data, ['1'])
+    expected = ({}, {'ssh-keys': '1'})
+    _AssertAttributeDict(data, expected)
 
     data = {'project': {'attributes': {'ssh-keys': '1', 'sshKeys': '2'}}}
-    _AssertAccountsData(data, ['1', '2'])
+    expected = ({}, {'ssh-keys': '1', 'sshKeys': '2'})
+    _AssertAttributeDict(data, expected)
 
     data = {
         'instance': {
@@ -216,7 +219,8 @@ class AccountsDaemonTest(unittest.TestCase):
             },
         },
     }
-    _AssertAccountsData(data, ['1', '2'])
+    expected = ({'ssh-keys': '1', 'sshKeys': '2'}, {'ssh-keys': '3'})
+    _AssertAttributeDict(data, expected)
 
     data = {
         'instance': {
@@ -231,7 +235,9 @@ class AccountsDaemonTest(unittest.TestCase):
             },
         },
     }
-    _AssertAccountsData(data, ['1', '2'])
+    expected = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
+                {'ssh-keys': '2'})
+    _AssertAttributeDict(data, expected)
 
     data = {
         'instance': {
@@ -246,7 +252,9 @@ class AccountsDaemonTest(unittest.TestCase):
             },
         },
     }
-    _AssertAccountsData(data, ['1'])
+    expected = ({'block-project-ssh-keys': 'true', 'ssh-keys': '1'},
+                {'ssh-keys': '2'})
+    _AssertAttributeDict(data, expected)
 
     data = {
         'instance': {
@@ -262,7 +270,116 @@ class AccountsDaemonTest(unittest.TestCase):
             },
         },
     }
+    expected = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
+                {'sshKeys': '3', 'ssh-keys': '2'})
+    _AssertAttributeDict(data, expected)
+
+  def testGetAccountsData(self):
+
+    def _AssertAccountsData(data, expected):
+      """Test the correct accounts data is returned.
+
+      Args:
+        data: dictionary, the faux metadata server contents.
+        expected: list, the faux SSH keys expected to be set.
+      """
+      self.mock_setup._GetInstanceAndProjectAttributes.return_value = data
+      accounts_daemon.AccountsDaemon._GetAccountsData(self.mock_setup, data)
+      if expected:
+        call_args, _ = self.mock_setup._ParseAccountsData.call_args
+        actual = call_args[0]
+        self.assertEqual(set(actual.split()), set(expected))
+      else:
+        self.mock_setup._ParseAccountsData.assert_called_once_with(expected)
+      self.mock_setup._ParseAccountsData.reset_mock()
+
+    data = ({}, {})
+    _AssertAccountsData(data, '')
+
+    data = ({'ssh-keys': '1'}, {})
+    _AssertAccountsData(data, ['1'])
+
+    data = ({'ssh-keys': '1', 'sshKeys': '2'}, {})
+    _AssertAccountsData(data, ['1', '2'])
+
+    data = ({}, {'ssh-keys': '1'})
+    _AssertAccountsData(data, ['1'])
+
+    data = ({}, {'ssh-keys': '1', 'sshKeys': '2'})
+    _AssertAccountsData(data, ['1', '2'])
+
+    data = ({'ssh-keys': '1', 'sshKeys': '2'}, {'ssh-keys': '3'})
+    _AssertAccountsData(data, ['1', '2'])
+
+    data = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
+                {'ssh-keys': '2'})
+    _AssertAccountsData(data, ['1', '2'])
+
+    data = ({'block-project-ssh-keys': 'true', 'ssh-keys': '1'},
+                {'ssh-keys': '2'})
+    _AssertAccountsData(data, ['1'])
+
+    data = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
+                {'sshKeys': '3', 'ssh-keys': '2'})
     _AssertAccountsData(data, ['1', '2', '3'])
+
+  def testGetEnableOsLoginValue(self):
+
+    def _AssertEnableOsLogin(data, expected):
+      """Test the correct value for enable-oslogin is returned.
+
+      Args:
+        data: dictionary, the faux metadata server contents.
+        expected: bool, if True, OS Login is enabled.
+      """
+      self.mock_setup._GetInstanceAndProjectAttributes.return_value = data
+      actual = accounts_daemon.AccountsDaemon._GetEnableOsLoginValue(self.mock_setup, data)
+      self.assertEqual(actual, expected)
+
+    data = ({}, {})
+    _AssertEnableOsLogin(data, False)
+
+    data = ({'enable-oslogin': 'true'}, {})
+    _AssertEnableOsLogin(data, True)
+
+    data = ({'enable-oslogin': 'false'}, {})
+    _AssertEnableOsLogin(data, False)
+
+    data = ({'enable-oslogin': 'yep'}, {})
+    _AssertEnableOsLogin(data, False)
+
+    data = ({'enable-oslogin': 'True'}, {})
+    _AssertEnableOsLogin(data, True)
+
+    data = ({'enable-oslogin': 'TRUE'}, {})
+    _AssertEnableOsLogin(data, True)
+
+    data = ({'enable-oslogin': ''}, {})
+    _AssertEnableOsLogin(data, False)
+
+    data = ({'enable-oslogin': 'true'}, {'enable-oslogin': 'true'})
+    _AssertEnableOsLogin(data, True)
+
+    data = ({'enable-oslogin': 'false'}, {'enable-oslogin': 'true'})
+    _AssertEnableOsLogin(data, False)
+
+    data = ({'enable-oslogin': ''}, {'enable-oslogin': 'true'})
+    _AssertEnableOsLogin(data, True)
+
+    data = ({}, {'enable-oslogin': 'true'})
+    _AssertEnableOsLogin(data, True)
+
+    data = ({}, {'enable-oslogin': 'false'})
+    _AssertEnableOsLogin(data, False)
+
+    data = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
+            {'sshKeys': '3', 'ssh-keys': '2'})
+    _AssertEnableOsLogin(data, False)
+
+    data = ({'block-project-ssh-keys': 'false', 'ssh-keys': '1'},
+            {'sshKeys': '3', 'ssh-keys': '2', 'enable-oslogin': 'true'})
+    _AssertEnableOsLogin(data, True)
+
 
   def testUpdateUsers(self):
     update_users = {
@@ -315,14 +432,17 @@ class AccountsDaemonTest(unittest.TestCase):
     self.assertEqual(self.mock_setup.invalid_users, set(['invalid']))
     self.assertEqual(self.mock_setup.user_ssh_keys, {'invalid': ['key']})
 
-  def testHandleAccounts(self):
+  def testHandleAccountsNoOsLogin(self):
     configured = ['c', 'c', 'b', 'b', 'a', 'a']
     desired = {'d': '1', 'c': '2'}
     mocks = mock.Mock()
     mocks.attach_mock(self.mock_utils, 'utils')
     mocks.attach_mock(self.mock_setup, 'setup')
+    mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_utils.GetConfiguredUsers.return_value = configured
     self.mock_setup._GetAccountsData.return_value = desired
+    self.mock_setup._GetEnableOsLoginValue.return_value = False
+    self.mock_oslogin.UpdateOsLogin.return_value = 0
     result = 'result'
     expected_add = ['c', 'd']
     expected_remove = ['a', 'b']
@@ -331,7 +451,9 @@ class AccountsDaemonTest(unittest.TestCase):
     expected_calls = [
         mock.call.setup.logger.debug(mock.ANY),
         mock.call.utils.GetConfiguredUsers(),
+        mock.call.setup._GetEnableOsLoginValue(result),
         mock.call.setup._GetAccountsData(result),
+        mock.call.oslogin.UpdateOsLogin(enable=False),
         mock.call.setup._UpdateUsers(desired),
         mock.call.setup._RemoveUsers(mock.ANY),
         mock.call.utils.SetConfiguredUsers(mock.ANY),
@@ -342,6 +464,36 @@ class AccountsDaemonTest(unittest.TestCase):
     call_args, _ = self.mock_setup._RemoveUsers.call_args
     self.assertEqual(set(call_args[0]), set(expected_remove))
 
+  def testHandleAccountsOsLogin(self):
+    configured = ['c', 'c', 'b', 'b', 'a', 'a']
+    desired = {}
+    mocks = mock.Mock()
+    mocks.attach_mock(self.mock_utils, 'utils')
+    mocks.attach_mock(self.mock_setup, 'setup')
+    mocks.attach_mock(self.mock_oslogin, 'oslogin')
+    self.mock_utils.GetConfiguredUsers.return_value = configured
+    self.mock_setup._GetAccountsData.return_value = desired
+    self.mock_setup._GetEnableOsLoginValue.return_value = True
+    self.mock_oslogin.UpdateOsLogin.return_value = 0
+    result = 'result'
+    expected_add = []
+    expected_remove = ['a', 'b', 'c']
+
+    accounts_daemon.AccountsDaemon.HandleAccounts(self.mock_setup, result)
+    expected_calls = [
+        mock.call.setup.logger.debug(mock.ANY),
+        mock.call.utils.GetConfiguredUsers(),
+        mock.call.setup._GetEnableOsLoginValue(result),
+        mock.call.oslogin.UpdateOsLogin(enable=True),
+        mock.call.setup._UpdateUsers(desired),
+        mock.call.setup._RemoveUsers(mock.ANY),
+        mock.call.utils.SetConfiguredUsers(mock.ANY),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+    call_args, _ = self.mock_utils.SetConfiguredUsers.call_args
+    self.assertEqual(set(call_args[0]), set(expected_add))
+    call_args, _ = self.mock_setup._RemoveUsers.call_args
+    self.assertEqual(set(call_args[0]), set(expected_remove))
 
 if __name__ == '__main__':
   unittest.main()

--- a/google_compute_engine/accounts/tests/accounts_daemon_test.py
+++ b/google_compute_engine/accounts/tests/accounts_daemon_test.py
@@ -495,5 +495,6 @@ class AccountsDaemonTest(unittest.TestCase):
     call_args, _ = self.mock_setup._RemoveUsers.call_args
     self.assertEqual(set(call_args[0]), set(expected_remove))
 
+
 if __name__ == '__main__':
   unittest.main()

--- a/google_compute_engine/accounts/tests/oslogin_utils_test.py
+++ b/google_compute_engine/accounts/tests/oslogin_utils_test.py
@@ -41,7 +41,7 @@ class OsLoginUtilsTest(unittest.TestCase):
         oslogin_utils.OsLoginUtils._RunOsLoginControl(
             self.mock_oslogin, 'activate'), expected_return_value)
     expected_calls = [
-        mock.call.call([self.oslogin_control_script, 'activate'])
+        mock.call.call([self.oslogin_control_script, 'activate']),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 
@@ -56,7 +56,7 @@ class OsLoginUtilsTest(unittest.TestCase):
         oslogin_utils.OsLoginUtils._RunOsLoginControl(
             self.mock_oslogin, 'status'), expected_return_value)
     expected_calls = [
-        mock.call.call([self.oslogin_control_script, 'status'])
+        mock.call.call([self.oslogin_control_script, 'status']),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 
@@ -70,7 +70,7 @@ class OsLoginUtilsTest(unittest.TestCase):
         oslogin_utils.OsLoginUtils._RunOsLoginControl(
             self.mock_oslogin, 'status'))
     expected_calls = [
-        mock.call.call([self.oslogin_control_script, 'status'])
+        mock.call.call([self.oslogin_control_script, 'status']),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 
@@ -83,13 +83,14 @@ class OsLoginUtilsTest(unittest.TestCase):
     with self.assertRaises(OSError):
       oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'status')
     expected_calls = [
-        mock.call.call([self.oslogin_control_script, 'status'])
+        mock.call.call([self.oslogin_control_script, 'status']),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 
   def testGetStatusActive(self):
     mocks = mock.Mock()
     self.mock_oslogin._RunOsLoginControl.return_value = 0
+
     self.assertTrue(oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin))
     expected_calls = []
     self.assertEqual(mocks.mock_calls, expected_calls)
@@ -97,6 +98,7 @@ class OsLoginUtilsTest(unittest.TestCase):
   def testGetStatusNotActive(self):
     mocks = mock.Mock()
     self.mock_oslogin._RunOsLoginControl.return_value = 3
+
     self.assertFalse(oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin))
     expected_calls = []
     self.assertEqual(mocks.mock_calls, expected_calls)
@@ -108,13 +110,11 @@ class OsLoginUtilsTest(unittest.TestCase):
 
     self.assertTrue(self.mock_oslogin.oslogin_installed)
     self.assertFalse(oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin))
-
     self.assertFalse(self.mock_oslogin.oslogin_installed)
     self.assertFalse(oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin))
-
     # Should only log once, even though called twice.
     expected_calls = [
-        mock.call.logger.warning(mock.ANY)
+        mock.call.logger.warning(mock.ANY),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 
@@ -124,8 +124,8 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = False
-    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
 
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
     expected_calls = [
         mock.call.oslogin._GetStatus(),
         mock.call.logger.warning(mock.ANY),
@@ -139,8 +139,8 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = True
-    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
 
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
     expected_calls = [
         mock.call.oslogin._GetStatus(),
         mock.call.logger.warning(mock.ANY),
@@ -153,8 +153,8 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = True
-    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
 
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
     expected_calls = [
         mock.call.oslogin._GetStatus(),
     ]
@@ -165,8 +165,8 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = False
-    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
 
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
     expected_calls = [
         mock.call.oslogin._GetStatus(),
     ]
@@ -177,8 +177,8 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = None
-    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
 
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
     expected_calls = [
         mock.call.oslogin._GetStatus(),
     ]

--- a/google_compute_engine/accounts/tests/oslogin_utils_test.py
+++ b/google_compute_engine/accounts/tests/oslogin_utils_test.py
@@ -30,38 +30,35 @@ class OsLoginUtilsTest(unittest.TestCase):
     self.mock_oslogin.logger = self.mock_logger
     self.mock_oslogin.oslogin_installed = True
 
-  def testRunOsLoginControl(self, mock_call):
-    mock_logger = mock.Mock()
-
-    oslogin = oslogin_utils.OsLoginUtils(
-        logger=mock_logger)
-    self.assertEqual(oslogin.logger, mock_logger)
-
   @mock.patch('google_compute_engine.accounts.oslogin_utils.subprocess.call')
   def testRunOsLoginControl(self, mock_call):
+    expected_return_value = 0
     mocks = mock.Mock()
     mocks.attach_mock(mock_call, 'call')
-    mock_call.return_value = 0
+    mock_call.return_value = expected_return_value
 
-    rv = oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'activate')
+    self.assertEqual(
+        oslogin_utils.OsLoginUtils._RunOsLoginControl(
+            self.mock_oslogin, 'activate'), expected_return_value)
     expected_calls = [
         mock.call.call([self.oslogin_control_script, 'activate'])
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
-    self.assertEqual(rv, 0)
 
   @mock.patch('google_compute_engine.accounts.oslogin_utils.subprocess.call')
   def testRunOsLoginControlStatus(self, mock_call):
+    expected_return_value = 3
     mocks = mock.Mock()
     mocks.attach_mock(mock_call, 'call')
-    mock_call.return_value = 3
+    mock_call.return_value = expected_return_value
 
-    rv = oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'status')
+    self.assertEqual(
+        oslogin_utils.OsLoginUtils._RunOsLoginControl(
+            self.mock_oslogin, 'status'), expected_return_value)
     expected_calls = [
         mock.call.call([self.oslogin_control_script, 'status'])
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
-    self.assertEqual(rv, 3)
 
   @mock.patch('google_compute_engine.accounts.oslogin_utils.subprocess.call')
   def testOsLoginNotInstalled(self, mock_call):
@@ -69,12 +66,13 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(mock_call, 'call')
     mock_call.side_effect = OSError(2, 'Not Found')
 
-    rv = oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'status')
+    self.assertIsNone(
+        oslogin_utils.OsLoginUtils._RunOsLoginControl(
+            self.mock_oslogin, 'status'))
     expected_calls = [
         mock.call.call([self.oslogin_control_script, 'status'])
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
-    self.assertEqual(rv, None)
 
   @mock.patch('google_compute_engine.accounts.oslogin_utils.subprocess.call')
   def testOsLoginControlError(self, mock_call):
@@ -83,7 +81,7 @@ class OsLoginUtilsTest(unittest.TestCase):
     mock_call.side_effect = OSError
 
     with self.assertRaises(OSError):
-      rv = oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'status')
+      oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'status')
     expected_calls = [
         mock.call.call([self.oslogin_control_script, 'status'])
     ]
@@ -92,16 +90,14 @@ class OsLoginUtilsTest(unittest.TestCase):
   def testGetStatusActive(self):
     mocks = mock.Mock()
     self.mock_oslogin._RunOsLoginControl.return_value = 0
-    status = oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin)
-    self.assertTrue(status)
+    self.assertTrue(oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin))
     expected_calls = []
     self.assertEqual(mocks.mock_calls, expected_calls)
 
   def testGetStatusNotActive(self):
     mocks = mock.Mock()
     self.mock_oslogin._RunOsLoginControl.return_value = 3
-    status = oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin)
-    self.assertFalse(status)
+    self.assertFalse(oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin))
     expected_calls = []
     self.assertEqual(mocks.mock_calls, expected_calls)
 
@@ -111,12 +107,10 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_logger, 'logger')
 
     self.assertTrue(self.mock_oslogin.oslogin_installed)
-    status1 = oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin)
-    self.assertFalse(status1)
+    self.assertFalse(oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin))
 
     self.assertFalse(self.mock_oslogin.oslogin_installed)
-    status2 = oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin)
-    self.assertFalse(status2)
+    self.assertFalse(oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin))
 
     # Should only log once, even though called twice.
     expected_calls = [
@@ -130,7 +124,7 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = False
-    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
 
     expected_calls = [
         mock.call.oslogin._GetStatus(),
@@ -145,7 +139,7 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = True
-    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
 
     expected_calls = [
         mock.call.oslogin._GetStatus(),
@@ -159,7 +153,7 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = True
-    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
 
     expected_calls = [
         mock.call.oslogin._GetStatus(),
@@ -171,7 +165,7 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = False
-    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
 
     expected_calls = [
         mock.call.oslogin._GetStatus(),
@@ -183,7 +177,7 @@ class OsLoginUtilsTest(unittest.TestCase):
     mocks.attach_mock(self.mock_oslogin, 'oslogin')
     self.mock_oslogin._RunOsLoginControl.return_value = 0
     self.mock_oslogin._GetStatus.return_value = None
-    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
+    oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
 
     expected_calls = [
         mock.call.oslogin._GetStatus(),

--- a/google_compute_engine/accounts/tests/oslogin_utils_test.py
+++ b/google_compute_engine/accounts/tests/oslogin_utils_test.py
@@ -1,0 +1,197 @@
+#!/usr/bin/python
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unittest for accounts_utils.py module."""
+
+from google_compute_engine.accounts import oslogin_utils
+from google_compute_engine.test_compat import mock
+from google_compute_engine.test_compat import unittest
+
+
+class AccountsUtilsTest(unittest.TestCase):
+
+  def setUp(self):
+    self.mock_logger = mock.Mock()
+    self.oslogin_control_script = 'google_oslogin_control'
+    #self.groupadd_cmd = 'groupadd {group}'
+
+    self.mock_oslogin = mock.create_autospec(oslogin_utils.OsLoginUtils)
+    self.mock_oslogin.logger = self.mock_logger
+    self.mock_oslogin.oslogin_installed = True
+    #self.mock_utils.groupadd_cmd = self.groupadd_cmd
+
+  def testRunOsLoginControl(self, mock_call):
+    mock_logger = mock.Mock()
+
+    oslogin = oslogin_utils.OsLoginUtils(
+        logger=mock_logger)
+    self.assertEqual(oslogin.logger, mock_logger)
+
+  @mock.patch('google_compute_engine.accounts.oslogin_utils.subprocess.call')
+  def testRunOsLoginControl(self, mock_call):
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_call, 'call')
+    mock_call.return_value = 0
+
+    rv = oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'activate')
+    expected_calls = [
+        mock.call.call([self.oslogin_control_script, 'activate'])
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+    self.assertEqual(rv, 0)
+
+  @mock.patch('google_compute_engine.accounts.oslogin_utils.subprocess.call')
+  def testRunOsLoginControlStatus(self, mock_call):
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_call, 'call')
+    mock_call.return_value = 3
+
+    rv = oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'status')
+    expected_calls = [
+        mock.call.call([self.oslogin_control_script, 'status'])
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+    self.assertEqual(rv, 3)
+
+  @mock.patch('google_compute_engine.accounts.oslogin_utils.subprocess.call')
+  def testOsLoginNotInstalled(self, mock_call):
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_call, 'call')
+    mock_call.side_effect = OSError(2, 'Not Found')
+
+    rv = oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'status')
+    expected_calls = [
+        mock.call.call([self.oslogin_control_script, 'status'])
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+    self.assertEqual(rv, None)
+
+  @mock.patch('google_compute_engine.accounts.oslogin_utils.subprocess.call')
+  def testOsLoginControlError(self, mock_call):
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_call, 'call')
+    mock_call.side_effect = OSError
+
+    with self.assertRaises(OSError):
+      rv = oslogin_utils.OsLoginUtils._RunOsLoginControl(self.mock_oslogin, 'status')
+    expected_calls = [
+        mock.call.call([self.oslogin_control_script, 'status'])
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  def testGetStatusActive(self):
+    mocks = mock.Mock()
+    self.mock_oslogin._RunOsLoginControl.return_value = 0
+    status = oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin)
+    self.assertTrue(status)
+    expected_calls = []
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  def testGetStatusNotActive(self):
+    mocks = mock.Mock()
+    self.mock_oslogin._RunOsLoginControl.return_value = 3
+    status = oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin)
+    self.assertFalse(status)
+    expected_calls = []
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  def testGetStatusNotInstalled(self):
+    mocks = mock.Mock()
+    self.mock_oslogin._RunOsLoginControl.return_value = None
+    mocks.attach_mock(self.mock_logger, 'logger')
+
+    self.assertTrue(self.mock_oslogin.oslogin_installed)
+    status1 = oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin)
+    self.assertFalse(status1)
+
+    self.assertFalse(self.mock_oslogin.oslogin_installed)
+    status2 = oslogin_utils.OsLoginUtils._GetStatus(self.mock_oslogin)
+    self.assertFalse(status2)
+
+    # Should only log once, even though called twice.
+    expected_calls = [
+        mock.call.logger.warning(mock.ANY)
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  def testUpdateOsLoginActivate(self):
+    mocks = mock.Mock()
+    mocks.attach_mock(self.mock_logger, 'logger')
+    mocks.attach_mock(self.mock_oslogin, 'oslogin')
+    self.mock_oslogin._RunOsLoginControl.return_value = 0
+    self.mock_oslogin._GetStatus.return_value = False
+    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
+
+    expected_calls = [
+        mock.call.oslogin._GetStatus(),
+        mock.call.logger.warning(mock.ANY),
+        mock.call.oslogin._RunOsLoginControl('activate'),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  def testUpdateOsLoginDeactivate(self):
+    mocks = mock.Mock()
+    mocks.attach_mock(self.mock_logger, 'logger')
+    mocks.attach_mock(self.mock_oslogin, 'oslogin')
+    self.mock_oslogin._RunOsLoginControl.return_value = 0
+    self.mock_oslogin._GetStatus.return_value = True
+    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
+
+    expected_calls = [
+        mock.call.oslogin._GetStatus(),
+        mock.call.logger.warning(mock.ANY),
+        mock.call.oslogin._RunOsLoginControl('deactivate'),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  def testUpdateOsLoginRedundantActivate(self):
+    mocks = mock.Mock()
+    mocks.attach_mock(self.mock_oslogin, 'oslogin')
+    self.mock_oslogin._RunOsLoginControl.return_value = 0
+    self.mock_oslogin._GetStatus.return_value = True
+    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
+
+    expected_calls = [
+        mock.call.oslogin._GetStatus(),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  def testUpdateOsLoginRedundantDeactivate(self):
+    mocks = mock.Mock()
+    mocks.attach_mock(self.mock_oslogin, 'oslogin')
+    self.mock_oslogin._RunOsLoginControl.return_value = 0
+    self.mock_oslogin._GetStatus.return_value = False
+    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, False)
+
+    expected_calls = [
+        mock.call.oslogin._GetStatus(),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+  def testUpdateOsLoginNotInstalled(self):
+    mocks = mock.Mock()
+    mocks.attach_mock(self.mock_oslogin, 'oslogin')
+    self.mock_oslogin._RunOsLoginControl.return_value = 0
+    self.mock_oslogin._GetStatus.return_value = None
+    status = oslogin_utils.OsLoginUtils.UpdateOsLogin(self.mock_oslogin, True)
+
+    expected_calls = [
+        mock.call.oslogin._GetStatus(),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/google_compute_engine/accounts/tests/oslogin_utils_test.py
+++ b/google_compute_engine/accounts/tests/oslogin_utils_test.py
@@ -13,24 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unittest for accounts_utils.py module."""
+"""Unittest for oslogin_utils.py module."""
 
 from google_compute_engine.accounts import oslogin_utils
 from google_compute_engine.test_compat import mock
 from google_compute_engine.test_compat import unittest
 
 
-class AccountsUtilsTest(unittest.TestCase):
+class OsLoginUtilsTest(unittest.TestCase):
 
   def setUp(self):
     self.mock_logger = mock.Mock()
     self.oslogin_control_script = 'google_oslogin_control'
-    #self.groupadd_cmd = 'groupadd {group}'
 
     self.mock_oslogin = mock.create_autospec(oslogin_utils.OsLoginUtils)
     self.mock_oslogin.logger = self.mock_logger
     self.mock_oslogin.oslogin_installed = True
-    #self.mock_utils.groupadd_cmd = self.groupadd_cmd
 
   def testRunOsLoginControl(self, mock_call):
     mock_logger = mock.Mock()

--- a/google_compute_engine/constants.py
+++ b/google_compute_engine/constants.py
@@ -17,6 +17,8 @@
 
 import platform
 
+OSLOGIN_CONTROL_SCRIPT = 'google_oslogin_control'
+
 if platform.system() == 'FreeBSD':
     LOCALBASE = '/usr/local'
     BOTOCONFDIR = '/usr/local'


### PR DESCRIPTION
Add the ability for the accounts daemon to activate/deactivate the OS Login features based on the 'enable-oslogin' metadata key.