### PR TITLE
RPM spec: specify version for python-google-compute-engine dependency.

### DIFF
--- a/specs/google-compute-engine.spec
+++ b/specs/google-compute-engine.spec
@@ -34,7 +34,7 @@ BuildRequires: systemd
 Requires: curl
 Requires: google-compute-engine-oslogin
 Requires: ntp
-Requires: python-google-compute-engine
+Requires: python-google-compute-engine = %{version}
 Requires: python-setuptools
 Requires: rsyslog
 %if 0%{?el7}


### PR DESCRIPTION
google-compute-engine requires python-google-compute-engine, but does not
specify the required version; this allows google-compute-engine to be upgraded
independently from the python distribution, which results in broken scripts.

Fixes #511.