### PR TITLE
Add systemd as valid ntp daemon

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Depends: google-compute-engine-oslogin,
          ${misc:Depends},
          python-google-compute-engine (= ${source:Version}),
          python3-google-compute-engine (= ${source:Version}),
-         chrony | ntp | time-daemon,
+         chrony | ntp | time-daemon | systemd,
          systemd
 Recommends: google-cloud-sdk
 Conflicts: google-compute-engine-jessie,


### PR DESCRIPTION
Hi,

We are using **systemd-timesyncd** as NTP daemon.

FYI, Debian don't plan to add systemd as virtual package to avoid problems with other NTP daemons nor to split systemd in several packages. All details in [the Debian dedicated bug report](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850169).

Could you add systemd as valid NTP daemon in the debian package ?

Thanks.