### PR TITLE
Fix home directory creation pam module.

### DIFF
--- a/google_compute_engine_oslogin/bin/google_oslogin_control
+++ b/google_compute_engine_oslogin/bin/google_oslogin_control
@@ -85,9 +85,9 @@ add_to_nss_config() {
 
 add_to_pam_config() {
   remove_from_config ${pam_config}
-  sed -i "/pam_nologin.so/ a${added_comment}\n${pam_admin}" ${pam_config}.new
-  sed -i "/pam_nologin.so/ a${added_comment}\n${pam_login}" ${pam_config}.new
-  sed -i "/pam_selinux.so close/ a${pam_homedir}" ${pam_config}.new
+  sed -i "/account.*pam_nologin.so/ a${added_comment}\n${pam_admin}" ${pam_config}.new
+  sed -i "/account.*pam_nologin.so/ a${added_comment}\n${pam_login}" ${pam_config}.new
+  sed -i "/pam_loginuid.so/ a${added_comment}\n${pam_homedir}" ${pam_config}.new
 }
 
 restart_service() {


### PR DESCRIPTION
For systems that don't have selinux, the old sed expression didn't work.
In addition, the mkhomedir module wasn't removed when deactivating
oslogin and under some circumstances, things could be added twice.