### PR TITLE
Latest pytest release dropped support for Python 2.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: true
 python:
-- 2.6
 - 2.7
 - 3.3
 - 3.4


### PR DESCRIPTION
The guest environment must still support Python 2.6.