### PR TITLE
Update hostname script to correctly restart rsyslog.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Depends: google-compute-engine-oslogin,
          python-google-compute-engine (= ${source:Version}),
          python3-google-compute-engine (= ${source:Version}),
          chrony | ntp | time-daemon | systemd,
+         rsyslog,
          systemd
 Recommends: google-cloud-sdk
 Conflicts: google-compute-engine-jessie,

--- a/google_config/bin/google_set_hostname
+++ b/google_config/bin/google_set_hostname
@@ -46,10 +46,10 @@ if [ -n "$new_host_name" ]; then
     nmcli general hostname "${new_host_name%%.*}"
   fi
 
-  # Restart syslog to update the hostname if we're not using systemd.
-  # systemd rsyslog jobs wait for networking to finish starting and consequently
-  # syslog or rsyslog is running with the correct hostname.
-  if [ ! -f /bin/systemctl ]; then
-    pkill -HUP syslogd
+  # Restart rsyslog to update the hostname.
+  if [ -f /etc/init.d/rsyslog ]; then
+    /etc/init.d/rsyslog restart
+  elif [ -f /bin/systemctl ]; then
+    systemctl -q --no-block restart rsyslog
   fi
 fi


### PR DESCRIPTION
- Add missing dependency for rsyslog to debian package.