### PR TITLE
Improve hostname setting

### DIFF
--- a/google_config/bin/google_set_hostname
+++ b/google_config/bin/google_set_hostname
@@ -37,19 +37,30 @@ fi
 # unqualified domain name.
 
 if [ -n "$new_host_name" ]; then
-  hostname "${new_host_name%%.*}"
+  hostnamectl=$( which hostnamectl 2> /dev/null )
+  if [ -x "$hostnamectl" ]; then
+    $hostnamectl set-hostname "$new_host_name"
+  else
+    # Assume hostname command exists
+    hostname "${new_host_name%%.*}"
+  fi
 
   # If NetworkManager is installed set the hostname with nmcli.
   # to resolve issues with NetworkManager resetting the hostname
   # to the FQDN on DHCP renew.
-  if [ -x /bin/nmcli ]; then
+  nmcli=$( which nmcli 2> /dev/null )
+  if [ -x "$nmcli" ]; then
     nmcli general hostname "${new_host_name%%.*}"
   fi
 
   # Restart rsyslog to update the hostname.
+  systemctl=$( which systemctl 2> /dev/null )
   if [ -f /etc/init.d/rsyslog ]; then
     /etc/init.d/rsyslog restart
-  elif [ -f /bin/systemctl ]; then
-    systemctl -q --no-block restart rsyslog
+  elif [ -x "$systemctl" ]; then
+    hasrsyslog=$( $systemctl | grep rsyslog | cut -f1 -d' ' )
+    if [ ! -z "$hasrsyslog" ]; then
+      $systemctl -q --no-block restart "$hasrsyslog"
+    fi
   fi
 fi

--- a/google_config/bin/google_set_hostname
+++ b/google_config/bin/google_set_hostname
@@ -41,7 +41,7 @@ if [ -n "$new_host_name" ]; then
   if [ -x "$hostnamectl" ]; then
     $hostnamectl set-hostname "$new_host_name"
   else
-    # Assume hostname command exists
+    # Assume hostname command exists.
     hostname "${new_host_name%%.*}"
   fi
 


### PR DESCRIPTION
  + Consider different locations for executables on different distributions
  + Prefer hostnamectl when available
  + Verify rsyslog service exists before attempting to restart
  + Do not depend on distro behavior that allows restart of service without
    the .service extension