### PR TITLE
Close socket connections when requesting metadata.

### DIFF
--- a/google_compute_engine_oslogin/utils/oslogin_utils.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.cc
@@ -157,6 +157,7 @@ bool HttpGet(const string& url, string* response, long* http_code) {
     struct curl_slist* header_list = NULL;
     header_list = curl_slist_append(header_list, "Metadata-Flavor: Google");
     if (header_list == NULL) {
+      curl_easy_cleanup(curl);
       curl_global_cleanup();
       return false;
     }
@@ -171,14 +172,17 @@ bool HttpGet(const string& url, string* response, long* http_code) {
 
       code = curl_easy_perform(curl);
       if (code != CURLE_OK) {
+        curl_easy_cleanup(curl);
+        curl_global_cleanup();
         return false;
       }
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, http_code);
     } while (retry_count++ < kMaxRetries && *http_code == 500);
     curl_slist_free_all(header_list);
-    curl_global_cleanup();
   }
   *response = response_stream.str();
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
   return true;
 }
 


### PR DESCRIPTION
Currently we are not cleaning up properly after OS Login related
metadata queries resulting in open socket connections.