### PR TITLE
Remove utils dependency on logger.

### DIFF
--- a/google_compute_engine/distro/utils.py
+++ b/google_compute_engine/distro/utils.py
@@ -15,27 +15,17 @@
 
 """Utilities that are distro specific."""
 
-import logging.handlers
-
-from google_compute_engine import logger as utils_logger
-from google_compute_engine import network_utils
-
 
 class Utils(object):
   """Utilities used by Linux guest services."""
 
-  def __init__(self, debug=False, logger=None):
+  def __init__(self, debug=False):
     """Constructor.
 
     Args:
       debug: bool, True if debug output should write to the console.
-      logger: logger object, used to write to SysLog and serial port.
     """
     self.debug = debug
-    facility = logging.handlers.SysLogHandler.LOG_DAEMON
-    self.logger = logger or utils_logger.Logger(
-        name='google-utils', debug=self.debug, facility=facility)
-    self.network_utils = network_utils.NetworkUtils(logger=self.logger)
 
   def EnableNetworkInterfaces(
       self, interfaces, logger, dhclient_script=None):

--- a/google_compute_engine/metadata_watcher.py
+++ b/google_compute_engine/metadata_watcher.py
@@ -67,7 +67,7 @@ def RetryOnUnavailable(func):
 class MetadataWatcher(object):
   """Watches for changes in metadata."""
 
-  def __init__(self, logger=logging, timeout=60):
+  def __init__(self, logger=None, timeout=60):
     """Constructor.
 
     Args:
@@ -75,7 +75,7 @@ class MetadataWatcher(object):
       timeout: int, timeout in seconds for metadata requests.
     """
     self.etag = 0
-    self.logger = logger
+    self.logger = logger or logging
     self.timeout = timeout
 
   @RetryOnUnavailable


### PR DESCRIPTION
This creates a circular dependency since compat imports utils and logger
imports compat.