### PR TITLE
Fix Debian dependencies for syslog and revert back syslog restart.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,9 +28,9 @@ Depends: google-compute-engine-oslogin,
          python-google-compute-engine (= ${source:Version}),
          python3-google-compute-engine (= ${source:Version}),
          chrony | ntp | time-daemon | systemd,
-         rsyslog,
+         system-log-daemon,
          systemd
-Recommends: google-cloud-sdk
+Recommends: google-cloud-sdk, rsyslog
 Conflicts: google-compute-engine-jessie,
            google-compute-engine-init-jessie,
            google-config-jessie,

--- a/google_config/bin/google_set_hostname
+++ b/google_config/bin/google_set_hostname
@@ -49,12 +49,12 @@ if [ -n "$new_host_name" ]; then
 
   # Restart rsyslog to update the hostname.
   systemctl=$(which systemctl 2> /dev/null)
-  if [ -f /etc/init.d/rsyslog ]; then
-    /etc/init.d/rsyslog restart
-  elif [ -x "$systemctl" ]; then
+  if [ -x "$systemctl" ]; then
     hasrsyslog=$($systemctl | grep rsyslog | cut -f1 -d' ')
     if [ ! -z "$hasrsyslog" ]; then
       $systemctl -q --no-block restart "$hasrsyslog"
     fi
+  else
+    pkill -HUP syslogd
   fi
 fi


### PR DESCRIPTION
In some cases, restarting using the init.d script can cause failures.
Revert back to nohup'ing the syslog process on systems without systemd
to prevent possible edge cases.