### PR TITLE
Clear the CURL_GLOBAL_SSL bit on curl initialization. Fixes #562.

### DIFF
--- a/google_compute_engine_oslogin/utils/oslogin_utils.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.cc
@@ -149,7 +149,7 @@ bool HttpGet(const string& url, string* response, long* http_code) {
     return false;
   }
   CURLcode code(CURLE_FAILED_INIT);
-  curl_global_init(CURL_GLOBAL_ALL);
+  curl_global_init(CURL_GLOBAL_ALL & ~CURL_GLOBAL_SSL);
   CURL* curl = curl_easy_init();
   std::ostringstream response_stream;
   int retry_count = 0;


### PR DESCRIPTION
This was breaking OpenSSL setup. Since oslogin does not use SSL while
communicating with the metadata server, we can clear this bit on
initialization. Fixes #562. 