### PR TITLE
Update the default value for cache update time.

### DIFF
--- a/google_compute_engine/accounts/oslogin_utils.py
+++ b/google_compute_engine/accounts/oslogin_utils.py
@@ -35,7 +35,7 @@ class OsLoginUtils(object):
     """
     self.logger = logger
     self.oslogin_installed = True
-    self.update_time = time.time()
+    self.update_time = 0
 
   def _RunOsLoginControl(self, action):
     """Run the OS Login control script.


### PR DESCRIPTION
The cache file should always be updated when the account daemon starts
and OS Login is enabled.