### PR TITLE
Return false on final page.

### DIFF
--- a/google_compute_engine_oslogin/utils/oslogin_utils.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.cc
@@ -118,7 +118,7 @@ bool NssCache::LoadJsonArrayToCache(string response) {
   if (page_token_ == "0") {
     page_token_ = "";
     on_last_page_ = true;
-    return true;
+    return false;
   }
   // Now grab all of the loginProfiles.
   json_object* login_profiles = NULL;


### PR DESCRIPTION
We were erroneously returning true on the last page, indicating to
callers that the passwd struct was valid. This manifested as a bug
where the nss_cache would write the last passd struct twice.