### PR TITLE
Update udev rules to name and symlink NVMe disks and partitions

### DIFF
--- a/google_config/udev/65-gce-disk-naming.rules
+++ b/google_config/udev/65-gce-disk-naming.rules
@@ -21,14 +21,14 @@ SUBSYSTEM!="block", GOTO="gce_disk_naming_end"
 KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
 
 # NVME naming
-KERNEL=="nvme0n1", ENV{ID_SERIAL_SHORT}="local-ssd-0"
-KERNEL=="nvme0n2", ENV{ID_SERIAL_SHORT}="local-ssd-1"
-KERNEL=="nvme0n3", ENV{ID_SERIAL_SHORT}="local-ssd-2"
-KERNEL=="nvme0n4", ENV{ID_SERIAL_SHORT}="local-ssd-3"
-KERNEL=="nvme0n5", ENV{ID_SERIAL_SHORT}="local-ssd-4"
-KERNEL=="nvme0n6", ENV{ID_SERIAL_SHORT}="local-ssd-5"
-KERNEL=="nvme0n7", ENV{ID_SERIAL_SHORT}="local-ssd-6"
-KERNEL=="nvme0n8", ENV{ID_SERIAL_SHORT}="local-ssd-7"
+KERNEL=="nvme0n1*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-0"
+KERNEL=="nvme0n2*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-1"
+KERNEL=="nvme0n3*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-2"
+KERNEL=="nvme0n4*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-3"
+KERNEL=="nvme0n5*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-4"
+KERNEL=="nvme0n6*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-5"
+KERNEL=="nvme0n7*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-6"
+KERNEL=="nvme0n8*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-7"
 KERNEL=="nvme*", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
 
 # Symlinks

--- a/google_config/udev/65-gce-disk-naming.rules
+++ b/google_config/udev/65-gce-disk-naming.rules
@@ -17,8 +17,22 @@
 ACTION!="add|change", GOTO="gce_disk_naming_end"
 SUBSYSTEM!="block", GOTO="gce_disk_naming_end"
 
+# SCSI naming
 KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
-KERNEL=="sd*|vd*", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"
-KERNEL=="sd*|vd*", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="partition", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}-part%n"
+
+# NVME naming
+KERNEL=="nvme0n1", ENV{ID_SERIAL_SHORT}="local-ssd-0"
+KERNEL=="nvme0n2", ENV{ID_SERIAL_SHORT}="local-ssd-1"
+KERNEL=="nvme0n3", ENV{ID_SERIAL_SHORT}="local-ssd-2"
+KERNEL=="nvme0n4", ENV{ID_SERIAL_SHORT}="local-ssd-3"
+KERNEL=="nvme0n5", ENV{ID_SERIAL_SHORT}="local-ssd-4"
+KERNEL=="nvme0n6", ENV{ID_SERIAL_SHORT}="local-ssd-5"
+KERNEL=="nvme0n7", ENV{ID_SERIAL_SHORT}="local-ssd-6"
+KERNEL=="nvme0n8", ENV{ID_SERIAL_SHORT}="local-ssd-7"
+KERNEL=="nvme*", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
+
+# Symlinks
+KERNEL=="sd*|vd*|nvme*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"
+KERNEL=="sd*|vd*|nvme*", ENV{DEVTYPE}=="partition", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}-part%n"
 
 LABEL="gce_disk_naming_end"


### PR DESCRIPTION
Fixes #485

Description:
We don't have custom naming/symlink rules for NVMe disks which results in them not getting unique symlinks under /dev/disk/by-id (when you have multiple NVMe disks all you get is a single nvme_card entry).

Fix:
Update the custom GCE udev rules file and add rules for NVMe disks. With this change, the NVMe disks will have symlinks (and ID_SERIAL and ID_SERIAL_SHORT attributes in case anyone relies on them) similar to those of SCSI disks.

Test Notes:
Verified that this works for CentOS 6, Debian 7, 8, 9, Ubuntu 16 and SUSE 12.