### PR TITLE
Update the name of the passwd cache file.

### DIFF
--- a/google_compute_engine/accounts/tests/oslogin_utils_test.py
+++ b/google_compute_engine/accounts/tests/oslogin_utils_test.py
@@ -27,7 +27,7 @@ class OsLoginUtilsTest(unittest.TestCase):
   def setUp(self):
     self.mock_logger = mock.Mock()
     self.oslogin_control_script = 'google_oslogin_control'
-    self.oslogin_nss_cache = '/etc/passwd.cache'
+    self.oslogin_nss_cache = '/etc/oslogin_passwd.cache'
     self.oslogin_nss_cache_script = 'google_oslogin_nss_cache'
 
     self.mock_oslogin = mock.create_autospec(oslogin_utils.OsLoginUtils)

--- a/google_compute_engine/constants.py
+++ b/google_compute_engine/constants.py
@@ -18,7 +18,7 @@
 import platform
 
 OSLOGIN_CONTROL_SCRIPT = 'google_oslogin_control'
-OSLOGIN_NSS_CACHE = '/etc/passwd.cache'
+OSLOGIN_NSS_CACHE = '/etc/oslogin_passwd.cache'
 OSLOGIN_NSS_CACHE_SCRIPT = 'google_oslogin_nss_cache'
 
 if platform.system() == 'FreeBSD':


### PR DESCRIPTION
When we enable and disable OS Login, this is the file that should be
updated or removed.