### PR TITLE
Prevent log spam from the IP forwarding daemon.

### DIFF
--- a/google_compute_engine/networking/ip_forwarding/ip_forwarding_utils.py
+++ b/google_compute_engine/networking/ip_forwarding/ip_forwarding_utils.py
@@ -111,6 +111,7 @@ class IpForwardingUtils(object):
     args = ['ls', 'table', 'local', 'type', 'local']
     options = self._CreateRouteOptions(dev=interface)
     result = self._RunIpRoute(args=args, options=options)
+    result = re.sub(r'local\s', r'', result)
     return self.ParseForwardedIps(result.split())
 
   def AddForwardedIp(self, address, interface):

--- a/google_compute_engine/networking/ip_forwarding/tests/ip_forwarding_utils_test.py
+++ b/google_compute_engine/networking/ip_forwarding/tests/ip_forwarding_utils_test.py
@@ -167,7 +167,7 @@ class IpForwardingUtilsTest(unittest.TestCase):
     mock_options = mock.Mock()
     mock_options.return_value = self.options
     mock_run = mock.Mock()
-    mock_run.return_value = 'a\nb\n'
+    mock_run.return_value = 'a\n b \nlocal c'
     mock_parse = mock.Mock()
     mock_parse.return_value = ['Test']
     self.mock_utils._CreateRouteOptions = mock_options
@@ -178,7 +178,7 @@ class IpForwardingUtilsTest(unittest.TestCase):
     mock_options.assert_called_once_with(dev='interface')
     mock_run.assert_called_once_with(
         args=['ls', 'table', 'local', 'type', 'local'], options=self.options)
-    mock_parse.assert_called_once_with(['a', 'b'])
+    mock_parse.assert_called_once_with(['a', 'b', 'c'])
 
   def testAddForwardedIp(self):
     mock_options = mock.Mock()


### PR DESCRIPTION
Forwarded IPs are returned with a local prefix. The agent splits on the
space and tries to add a route for the IP "local" which generates log
spam. We should strip out the local prefix to prevent this issue.