### PR TITLE
Revert "instance_setup: _StartSshd: test rc.d for FreeBSD (#593)"

### DIFF
--- a/google_compute_engine/instance_setup/instance_setup.py
+++ b/google_compute_engine/instance_setup/instance_setup.py
@@ -152,8 +152,7 @@ class InstanceSetup(object):
       subprocess.call(['service', 'ssh', 'start'])
       subprocess.call(['service', 'ssh', 'reload'])
     elif (os.path.exists('/etc/init.d/sshd') or
-          os.path.exists('/etc/init/sshd.conf') or
-          os.path.exists('/etc/rc.d/sshd')):
+          os.path.exists('/etc/init/sshd.conf')):
       subprocess.call(['service', 'sshd', 'start'])
       subprocess.call(['service', 'sshd', 'reload'])
 

--- a/google_compute_engine/instance_setup/tests/instance_setup_test.py
+++ b/google_compute_engine/instance_setup/tests/instance_setup_test.py
@@ -299,27 +299,6 @@ class InstanceSetupTest(unittest.TestCase):
 
   @mock.patch('google_compute_engine.instance_setup.instance_setup.subprocess.call')
   @mock.patch('google_compute_engine.instance_setup.instance_setup.os.path.exists')
-  def testStartSshdRcFreebsd(self, mock_exists, mock_call):
-    mocks = mock.Mock()
-    mocks.attach_mock(mock_exists, 'exists')
-    mocks.attach_mock(mock_call, 'call')
-    mock_exists.side_effect = [False, False, False, False, False, True]
-
-    instance_setup.InstanceSetup._StartSshd(self.mock_setup)
-    expected_calls = [
-        mock.call.exists('/bin/systemctl'),
-        mock.call.exists('/etc/init.d/ssh'),
-        mock.call.exists('/etc/init/ssh.conf'),
-        mock.call.exists('/etc/init.d/sshd'),
-        mock.call.exists('/etc/init/sshd.conf'),
-        mock.call.exists('/etc/rc.d/sshd'),
-        mock.call.call(['service', 'sshd', 'start']),
-        mock.call.call(['service', 'sshd', 'reload']),
-    ]
-    self.assertEqual(mocks.mock_calls, expected_calls)
-
-  @mock.patch('google_compute_engine.instance_setup.instance_setup.subprocess.call')
-  @mock.patch('google_compute_engine.instance_setup.instance_setup.os.path.exists')
   def testStartSshdSystemd(self, mock_exists, mock_call):
     mocks = mock.Mock()
     mocks.attach_mock(mock_exists, 'exists')


### PR DESCRIPTION
This reverts commit 8093d7c6cb798d7c6fad7247313d8d66b892dde8.

Reason:
google_instance_setup starts sshd after generating host keys, but when
FreeBSD boots, this service starts before sshd.
FreeBSD starts sshd through rc utility on boot regardless if
it was already started before. Causing the following error:

```
Starting sshd.
May 15 16:51:18 freebsd sshd[1365]: error: Bind to port 22 on :: failed: Address already in use.
May 15 16:51:18 freebsd sshd[1365]: error: Bind to port 22 on :: failed: Address already in use.
May 15 16:51:18 freebsd sshd[1365]: error: Bind to port 22 on 0.0.0.0 failed: Address already in use.
May 15 16:51:18 freebsd sshd[1365]: error: Bind to port 22 on 0.0.0.0 failed: Address already in use.
May 15 16:51:18 freebsd sshd[1365]: fatal: Cannot bind any address.
May 15 16:51:18 freebsd sshd[1365]: fatal: Cannot bind any address.
```

Solution:
Don't start ssh in instance_setup for FreeBSD, let the rc utility to start it.