### PR TITLE
- Properly handle distro detection for Python 3.6 and greater

### DIFF
--- a/google_compute_engine/compat.py
+++ b/google_compute_engine/compat.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 
 if sys.version_info >= (3, 6):
-  import distro
+  import google_compute_engine.distro as distro
 else:
   import platform as distro
 

--- a/google_compute_engine/distro/__init__.py
+++ b/google_compute_engine/distro/__init__.py
@@ -1,0 +1,20 @@
+import os
+import platform
+
+def linux_distribution():
+    """Determine the distribution by reading /etc/os-release"""
+    distro_name = '',
+    distro_version = ''
+    release_file = '/etc/os-release'
+    if os.path.exists(release_file):
+        with open(release_file) as os_release:
+            for line in os_release.readlines():
+                if line.strip().startswith('ID='):
+                    distro_name = line.split('=')[-1]
+                    distro_name = distro_name.replace('"', '')
+                if line.strip().startswith('VERSION_ID='):
+                    # Lets hope for the best that distros stay consistent ;)
+                    distro_version = line.split('=')[-1]
+                    distro_version = distro_version.replace('"', '')
+    return (distro_name, distro_version, platform.machine())
+                


### PR DESCRIPTION
  + The present implementation fails on relative import of "distro" and
    "distro" does not have an implementation of "linux_distribution" which
    is called in any Python version. This commit addresses both problems,
    changing the import to absolute and implementing "linux_distribution"
    to return values based on "/etc/os-release"