### PR TITLE
OSLogin partially fails when username is greater than 32 characters

### DIFF
--- a/google_compute_engine/accounts/accounts_utils.py
+++ b/google_compute_engine/accounts/accounts_utils.py
@@ -26,7 +26,7 @@ import tempfile
 from google_compute_engine import constants
 from google_compute_engine import file_utils
 
-USER_REGEX = re.compile(r'\A[A-Za-z0-9._][A-Za-z0-9._-]*\Z')
+USER_REGEX = re.compile(r'\A[A-Za-z0-9._][A-Za-z0-9._-]{0,31}\Z')
 DEFAULT_GROUPADD_CMD = 'groupadd {group}'
 DEFAULT_USERADD_CMD = 'useradd -m -s /bin/bash -p * {user}'
 DEFAULT_USERDEL_CMD = 'userdel -r {user}'

--- a/google_compute_engine/accounts/tests/accounts_utils_test.py
+++ b/google_compute_engine/accounts/tests/accounts_utils_test.py
@@ -572,6 +572,7 @@ class AccountsUtilsTest(unittest.TestCase):
         'abc xyz',
         'xyz*',
         'xyz$',
+        'areallylongusernamethatexceedsthethirtytwocharacterlimit'
     ]
     for user in invalid_users:
       self.assertFalse(


### PR DESCRIPTION
A user with a username greater than 32 characters (name and email with
special characters converted to _) logged into an instance with
OSLogin enabled.  The user received "No user exists for uid XXXX"
messages when attempting to run programs.  This change truncates the
username to 32 characters for utilities that take a username.