### PR TITLE
Prevent setup of the default ethernet interface.

### DIFF
--- a/google_compute_engine/networking/network_daemon.py
+++ b/google_compute_engine/networking/network_daemon.py
@@ -91,7 +91,7 @@ class NetworkDaemon(object):
 
     if self.network_setup_enabled:
       self.network_setup.EnableNetworkInterfaces(
-          [interface.name for interface in network_interfaces])
+          [interface.name for interface in network_interfaces[1:]])
 
     for interface in network_interfaces:
       if self.ip_forwarding_enabled:

--- a/google_compute_engine/networking/network_setup/network_setup.py
+++ b/google_compute_engine/networking/network_setup/network_setup.py
@@ -56,8 +56,6 @@ class NetworkSetup(object):
 
     self.logger.info('Ethernet interfaces: %s.', interfaces)
     self.interfaces = set(interfaces)
-    if len(interfaces) <= 1:
-      return
 
     if self.dhcp_command:
       try:

--- a/google_compute_engine/networking/network_setup/tests/network_setup_test.py
+++ b/google_compute_engine/networking/network_setup/tests/network_setup_test.py
@@ -72,29 +72,25 @@ class NetworkSetupTest(unittest.TestCase):
     network_setup.NetworkSetup.EnableNetworkInterfaces(
         self.mock_setup, ['A', 'B', 'C'])
     self.assertEqual(self.mock_setup.interfaces, set(['A', 'B', 'C']))
-    # A single interface is enabled by default.
-    network_setup.NetworkSetup.EnableNetworkInterfaces(self.mock_setup, ['D'])
-    self.assertEqual(self.mock_setup.interfaces, set(['D']))
     # Run a user supplied command successfully.
     self.mock_setup.dhcp_command = 'success'
     network_setup.NetworkSetup.EnableNetworkInterfaces(
-        self.mock_setup, ['E', 'F'])
-    self.assertEqual(self.mock_setup.interfaces, set(['E', 'F']))
+        self.mock_setup, ['D', 'E'])
+    self.assertEqual(self.mock_setup.interfaces, set(['D', 'E']))
     # Run a user supplied command and logger error messages.
     self.mock_setup.dhcp_command = 'failure'
     network_setup.NetworkSetup.EnableNetworkInterfaces(
-        self.mock_setup, ['G', 'H'])
-    self.assertEqual(self.mock_setup.interfaces, set(['G', 'H']))
+        self.mock_setup, ['F', 'G'])
+    self.assertEqual(self.mock_setup.interfaces, set(['F', 'G']))
     expected_calls = [
         mock.call.logger.info(mock.ANY, ['A', 'B']),
         mock.call.enable(['A', 'B'], mock.ANY, dhclient_script='/bin/script'),
         mock.call.logger.info(mock.ANY, ['A', 'B', 'C']),
         mock.call.enable(
             ['A', 'B', 'C'], mock.ANY, dhclient_script='/bin/script'),
-        mock.call.logger.info(mock.ANY, ['D']),
-        mock.call.logger.info(mock.ANY, ['E', 'F']),
+        mock.call.logger.info(mock.ANY, ['D', 'E']),
         mock.call.call(['success']),
-        mock.call.logger.info(mock.ANY, ['G', 'H']),
+        mock.call.logger.info(mock.ANY, ['F', 'G']),
         mock.call.call(['failure']),
         mock.call.logger.warning(mock.ANY),
     ]

--- a/google_compute_engine/networking/tests/network_daemon_test.py
+++ b/google_compute_engine/networking/tests/network_daemon_test.py
@@ -148,7 +148,7 @@ class NetworkDaemonTest(unittest.TestCase):
         self.mock_setup, result)
     expected_calls = [
         mock.call.setup._ExtractInterfaceMetadata(result),
-        mock.call.network_setup.EnableNetworkInterfaces(['a', 'b']),
+        mock.call.network_setup.EnableNetworkInterfaces(['b']),
         mock.call.forwarding.HandleForwardedIps('a', None, None),
         mock.call.forwarding.HandleForwardedIps('b', None, None),
     ]


### PR DESCRIPTION
The default ethernet interface is already enabled. We should not run
dhclient on the interface.