### PR TITLE
Return false on failed final load.

### DIFF
--- a/google_compute_engine_oslogin/utils/oslogin_utils.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.cc
@@ -154,9 +154,12 @@ bool NssCache::NssGetpwentHelper(BufferManager* buf, struct passwd* result,
     string response;
     long http_code = 0;
     if (!HttpGet(url.str(), &response, &http_code) || http_code != 200 ||
-        response.empty() ||
-        (!LoadJsonArrayToCache(response) && !on_last_page_)) {
-      *errnop = ENOENT;
+        response.empty() || !LoadJsonArrayToCache(response)) {
+      // It is possible this to be true after LoadJsonArrayToCache(), so we
+      // must check it again.
+      if(!OnLastPage()) {
+        *errnop = ENOENT;
+      }
       return false;
     }
   }


### PR DESCRIPTION
There were still legitimate cases where we fail LoadJsonArrayToCache() and are on the last page, which would cause us to skip this path and accidentally return true.