### PR TITLE
Enable IPv6 on interfaces based on metadata key.

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/debian_8/tests/utils_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/debian_8/tests/utils_test.py
@@ -26,6 +26,15 @@ class UtilsTest(unittest.TestCase):
     self.mock_logger = mock.Mock()
     self.mock_setup = mock.create_autospec(utils.Utils)
 
+  @mock.patch('google_compute_engine.distro_lib.helpers.CallDhclientIpv6')
+  def testEnableIpv6(self, mock_call):
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_call, 'call')
+
+    utils.Utils.EnableIpv6(self.mock_setup, ['A', 'B'], self.mock_logger)
+    expected_calls = [mock.call.call(['A', 'B'], mock.ANY)]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
   @mock.patch('google_compute_engine.distro_lib.helpers.CallDhclient')
   def testEnableNetworkInterfaces(self, mock_call):
     mocks = mock.Mock()

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/debian_8/utils.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/debian_8/utils.py
@@ -23,8 +23,17 @@ from google_compute_engine.distro_lib import utils
 class Utils(utils.Utils):
   """Utilities used by Linux guest services on Debian 8."""
 
-  def EnableNetworkInterfaces(
-      self, interfaces, logger, dhclient_script=None):
+  def EnableIpv6(self, interfaces, logger, dhclient_script=None):
+    """Configure the network interfaces for IPv6 using dhclient.
+
+    Args:
+      interface: string, the output device names for enabling IPv6.
+      logger: logger object, used to write to SysLog and serial port.
+      dhclient_script: string, the path to a dhclient script used by dhclient.
+    """
+    helpers.CallDhclientIpv6(interfaces, logger)
+
+  def EnableNetworkInterfaces(self, interfaces, logger, dhclient_script=None):
     """Enable the list of network interfaces.
 
     Args:

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/debian_9/tests/utils_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/debian_9/tests/utils_test.py
@@ -26,6 +26,15 @@ class UtilsTest(unittest.TestCase):
     self.mock_logger = mock.Mock()
     self.mock_setup = mock.create_autospec(utils.Utils)
 
+  @mock.patch('google_compute_engine.distro_lib.helpers.CallDhclientIpv6')
+  def testEnableIpv6(self, mock_call):
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_call, 'call')
+
+    utils.Utils.EnableIpv6(self.mock_setup, ['A', 'B'], self.mock_logger)
+    expected_calls = [mock.call.call(['A', 'B'], mock.ANY)]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
   @mock.patch('google_compute_engine.distro_lib.helpers.CallDhclient')
   def testEnableNetworkInterfaces(self, mock_call):
     mocks = mock.Mock()

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/debian_9/utils.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/debian_9/utils.py
@@ -23,8 +23,17 @@ from google_compute_engine.distro_lib import utils
 class Utils(utils.Utils):
   """Utilities used by Linux guest services on Debian 9."""
 
-  def EnableNetworkInterfaces(
-      self, interfaces, logger, dhclient_script=None):
+  def EnableIpv6(self, interfaces, logger, dhclient_script=None):
+    """Configure the network interfaces for IPv6 using dhclient.
+
+    Args:
+      interface: string, the output device names for enabling IPv6.
+      logger: logger object, used to write to SysLog and serial port.
+      dhclient_script: string, the path to a dhclient script used by dhclient.
+    """
+    helpers.CallDhclientIpv6(interfaces, logger)
+
+  def EnableNetworkInterfaces(self, interfaces, logger, dhclient_script=None):
     """Enable the list of network interfaces.
 
     Args:

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/el_6/tests/utils_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/el_6/tests/utils_test.py
@@ -29,6 +29,19 @@ class UtilsTest(unittest.TestCase):
   def tearDown(self):
     pass
 
+  @mock.patch('google_compute_engine.distro_lib.helpers.CallDhclientIpv6')
+  def testEnableIpv6(self, mock_call):
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_call, 'call')
+
+    utils.Utils.EnableIpv6(
+        self.mock_setup, ['A', 'B'], self.mock_logger,
+        dhclient_script='test_script')
+    expected_calls = [
+        mock.call.call(['A', 'B'], mock.ANY, dhclient_script='test_script'),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
   @mock.patch('google_compute_engine.distro_lib.helpers.CallDhclient')
   def testEnableNetworkInterfaces(self, mock_call):
     mocks = mock.Mock()

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/el_6/utils.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/el_6/utils.py
@@ -21,10 +21,20 @@ from google_compute_engine.distro_lib import utils
 
 
 class Utils(utils.Utils):
-  """Utilities used by Linux guest services on Debian 8."""
+  """Utilities used by Linux guest services on EL 6."""
 
-  def EnableNetworkInterfaces(
-      self, interfaces, logger, dhclient_script=None):
+  def EnableIpv6(self, interfaces, logger, dhclient_script=None):
+    """Configure the network interfaces for IPv6 using dhclient.
+
+    Args:
+      interface: string, the output device names for enabling IPv6.
+      logger: logger object, used to write to SysLog and serial port.
+      dhclient_script: string, the path to a dhclient script used by dhclient.
+    """
+    helpers.CallDhclientIpv6(
+        interfaces, logger, dhclient_script=dhclient_script)
+
+  def EnableNetworkInterfaces(self, interfaces, logger, dhclient_script=None):
     """Enable the list of network interfaces.
 
     Args:

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/el_7/tests/utils_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/el_7/tests/utils_test.py
@@ -96,6 +96,15 @@ class UtilsTest(unittest.TestCase):
       ]
       self.assertEqual(mocks.mock_calls, expected_calls)
 
+  @mock.patch('google_compute_engine.distro_lib.helpers.CallDhclientIpv6')
+  def testEnableIpv6(self, mock_call):
+    mocks = mock.Mock()
+    mocks.attach_mock(mock_call, 'call')
+
+    utils.Utils.EnableIpv6(self.mock_setup, ['A', 'B'], self.mock_logger)
+    expected_calls = [mock.call.call(['A', 'B'], mock.ANY)]
+    self.assertEqual(mocks.mock_calls, expected_calls)
+
   @mock.patch('google_compute_engine.distro_lib.el_7.utils.os.path.exists')
   @mock.patch('google_compute_engine.distro_lib.helpers.CallDhclient')
   def testEnableNetworkInterfaces(self, mock_call, mock_exists):

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/el_7/utils.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/el_7/utils.py
@@ -30,8 +30,17 @@ class Utils(utils.Utils):
 
   network_path = constants.LOCALBASE + '/etc/sysconfig/network-scripts'
 
-  def EnableNetworkInterfaces(
-      self, interfaces, logger, dhclient_script=None):
+  def EnableIpv6(self, interfaces, logger, dhclient_script=None):
+    """Configure the network interfaces for IPv6 using dhclient.
+
+    Args:
+      interface: string, the output device names for enabling IPv6.
+      logger: logger object, used to write to SysLog and serial port.
+      dhclient_script: string, the path to a dhclient script used by dhclient.
+    """
+    helpers.CallDhclientIpv6(interfaces, logger)
+
+  def EnableNetworkInterfaces(self, interfaces, logger, dhclient_script=None):
     """Enable the list of network interfaces.
 
     Args:

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/freebsd_11/utils.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/freebsd_11/utils.py
@@ -23,8 +23,17 @@ from google_compute_engine.distro_lib import utils
 class Utils(utils.Utils):
   """Utilities used by Linux guest services on FreeBSD 11."""
 
-  def EnableNetworkInterfaces(
-      self, interfaces, logger, dhclient_script=None):
+  def EnableIpv6(self, interfaces, logger, dhclient_script=None):
+    """Configure the network interfaces for IPv6 using dhclient.
+
+    Args:
+      interface: string, the output device names for enabling IPv6.
+      logger: logger object, used to write to SysLog and serial port.
+      dhclient_script: string, the path to a dhclient script used by dhclient.
+    """
+    pass
+
+  def EnableNetworkInterfaces(self, interfaces, logger, dhclient_script=None):
     """Enable the list of network interfaces.
 
     Args:

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/helpers.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/helpers.py
@@ -42,6 +42,27 @@ def CallDhclient(
     logger.warning('Could not enable interfaces %s.', interfaces)
 
 
+def CallDhclientIpv6(interfaces, logger, dhclient_script=None):
+  """Configure the network interfaces for IPv6 using dhclient.
+
+  Args:
+    interface: string, the output device names for enabling IPv6.
+    logger: logger object, used to write to SysLog and serial port.
+    dhclient_script: string, the path to a dhclient script used by dhclient.
+  """
+  logger.info('Enabling IPv6 on the Ethernet interfaces %s.', interfaces)
+
+  dhclient_command = ['dhclient']
+
+  if dhclient_script and os.path.exists(dhclient_script):
+    dhclient_command += ['-sf', dhclient_script]
+
+  try:
+    subprocess.check_call(dhclient_command + ['-1', '-6', '-v'] + interfaces)
+  except subprocess.CalledProcessError:
+    logger.warning('Could not enable IPv6 on interface %s.', interfaces)
+
+
 def CallHwclock(logger):
   """Sync clock using hwclock.
 

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/helpers.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/helpers.py
@@ -52,13 +52,15 @@ def CallDhclientIpv6(interfaces, logger, dhclient_script=None):
   """
   logger.info('Enabling IPv6 on the Ethernet interfaces %s.', interfaces)
 
+  timeout_command = ['timeout', '5']
   dhclient_command = ['dhclient']
 
   if dhclient_script and os.path.exists(dhclient_script):
     dhclient_command += ['-sf', dhclient_script]
 
   try:
-    subprocess.check_call(dhclient_command + ['-1', '-6', '-v'] + interfaces)
+    subprocess.check_call(
+        timeout_command + dhclient_command + ['-1', '-6', '-v'] + interfaces)
   except subprocess.CalledProcessError:
     logger.warning('Could not enable IPv6 on interface %s.', interfaces)
 

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/sles_11/utils.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/sles_11/utils.py
@@ -27,8 +27,17 @@ from google_compute_engine.distro_lib import utils
 class Utils(utils.Utils):
   """Utilities used by Linux guest services on SUSE 11."""
 
-  def EnableNetworkInterfaces(
-      self, interfaces, logger, dhclient_script=None):
+  def EnableIpv6(self, interfaces, logger, dhclient_script=None):
+    """Configure the network interfaces for IPv6 using dhclient.
+
+    Args:
+      interface: string, the output device names for enabling IPv6.
+      logger: logger object, used to write to SysLog and serial port.
+      dhclient_script: string, the path to a dhclient script used by dhclient.
+    """
+    pass
+
+  def EnableNetworkInterfaces(self, interfaces, logger, dhclient_script=None):
     """Enable the list of network interfaces.
 
     Args:

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/sles_12/utils.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/sles_12/utils.py
@@ -29,8 +29,17 @@ class Utils(utils.Utils):
 
   network_path = constants.LOCALBASE + '/etc/sysconfig/network'
 
-  def EnableNetworkInterfaces(
-      self, interfaces, logger, dhclient_script=None):
+  def EnableIpv6(self, interfaces, logger, dhclient_script=None):
+    """Configure the network interfaces for IPv6 using dhclient.
+
+    Args:
+      interface: string, the output device names for enabling IPv6.
+      logger: logger object, used to write to SysLog and serial port.
+      dhclient_script: string, the path to a dhclient script used by dhclient.
+    """
+    pass
+
+  def EnableNetworkInterfaces(self, interfaces, logger, dhclient_script=None):
     """Enable the list of network interfaces.
 
     Args:

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/tests/helpers_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/tests/helpers_test.py
@@ -86,15 +86,19 @@ class HelpersTest(unittest.TestCase):
     expected_calls = [
         mock.call.logger.info(mock.ANY, ['a', 'b']),
         mock.call.exists('test_script'),
-        mock.call.call(['dhclient', '-1', '-6', '-v', 'a', 'b']),
+        mock.call.call(
+            ['timeout', '5', 'dhclient', '-1', '-6', '-v', 'a', 'b']),
         mock.call.logger.info(mock.ANY, ['c', 'd']),
         mock.call.exists('test_script'),
         mock.call.call(
-            ['dhclient', '-sf', 'test_script', '-1', '-6', '-v', 'c', 'd']),
+            ['timeout', '5', 'dhclient', '-sf', 'test_script', '-1', '-6',
+             '-v', 'c', 'd']),
         mock.call.logger.info(mock.ANY, ['e', 'f']),
-        mock.call.call(['dhclient', '-1', '-6', '-v', 'e', 'f']),
+        mock.call.call(
+            ['timeout', '5', 'dhclient', '-1', '-6', '-v', 'e', 'f']),
         mock.call.logger.info(mock.ANY, ['g', 'h']),
-        mock.call.call(['dhclient', '-1', '-6', '-v', 'g', 'h']),
+        mock.call.call(
+            ['timeout', '5', 'dhclient', '-1', '-6', '-v', 'g', 'h']),
         mock.call.logger.warning(mock.ANY, ['g', 'h']),
     ]
 

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/utils.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/utils.py
@@ -27,8 +27,17 @@ class Utils(object):
     """
     self.debug = debug
 
-  def EnableNetworkInterfaces(
-      self, interfaces, logger, dhclient_script=None):
+  def EnableIpv6(self, interfaces, logger, dhclient_script=None):
+    """Enable IPv6 on the list of network interfaces.
+
+    Args:
+      interfaces: list of string, the output device names for enabling IPv6.
+      logger: logger object, used to write to SysLog and serial port.
+      dhclient_script: string, the path to a dhclient script used by dhclient.
+    """
+    pass
+
+  def EnableNetworkInterfaces(self, interfaces, logger, dhclient_script=None):
     """Enable the list of network interfaces.
 
     Args:

--- a/packages/python-google-compute-engine/google_compute_engine/networking/network_setup/network_setup.py
+++ b/packages/python-google-compute-engine/google_compute_engine/networking/network_setup/network_setup.py
@@ -26,6 +26,7 @@ class NetworkSetup(object):
   """Enable network interfaces."""
 
   interfaces = set()
+  ipv6_interfaces = set()
   network_interfaces = 'instance/network-interfaces'
 
   def __init__(self, dhclient_script=None, dhcp_command=None, debug=False):
@@ -42,6 +43,22 @@ class NetworkSetup(object):
     self.logger = logger.Logger(
         name='network-setup', debug=debug, facility=facility)
     self.distro_utils = distro_utils.Utils(debug=debug)
+
+  def EnableIpv6(self, interfaces):
+    """Enable IPv6 on the list of network interfaces.
+
+    Args:
+      interfaces: list of string, the output device names for enabling IPv6.
+    """
+    if not interfaces or set(interfaces) == self.ipv6_interfaces:
+      return
+
+    self.logger.info('Enabling IPv6 on Ethernet interface: %s.', interfaces)
+    self.ipv6_interfaces = set(interfaces)
+
+    # Distro-specific setup for enabling IPv6 on network interfaces.
+    self.distro_utils.EnableIpv6(
+        interfaces, self.logger, dhclient_script=self.dhclient_script)
 
   def EnableNetworkInterfaces(self, interfaces):
     """Enable the list of network interfaces.

--- a/packages/python-google-compute-engine/google_compute_engine/networking/network_setup/tests/network_setup_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/networking/network_setup/tests/network_setup_test.py
@@ -27,61 +27,79 @@ class NetworkSetupTest(unittest.TestCase):
   def setUp(self):
     self.mock_logger = mock.Mock()
     self.mock_distro_utils = mock.Mock()
-    self.mock_setup = mock.create_autospec(network_setup.NetworkSetup)
-    self.mock_setup.logger = self.mock_logger
-    self.mock_setup.distro_utils = self.mock_distro_utils
-    self.mock_setup.dhclient_script = '/bin/script'
-    self.mock_setup.dhcp_command = ''
+    self.dhclient_script = '/bin/script'
+    self.dhcp_command = ''
+    self.setup = network_setup.NetworkSetup(
+        dhclient_script=self.dhclient_script, dhcp_command=self.dhcp_command,
+        debug=False)
+    self.setup.distro_utils = self.mock_distro_utils
+    self.setup.logger = self.mock_logger
 
-  @mock.patch('google_compute_engine.networking.network_setup.network_setup.logger')
-  def testNetworkSetup(self, mock_logger):
-    mock_logger_instance = mock.Mock()
-    mock_logger.Logger.return_value = mock_logger_instance
+  @mock.patch('google_compute_engine.networking.network_setup.network_setup.subprocess.check_call')
+  def testEnableIpv6(self, mock_call):
     mocks = mock.Mock()
-    mocks.attach_mock(mock_logger, 'logger')
-    with mock.patch.object(
-        network_setup.NetworkSetup, 'EnableNetworkInterfaces'):
+    mocks.attach_mock(mock_call, 'call')
+    mocks.attach_mock(self.mock_logger, 'logger')
+    mocks.attach_mock(self.mock_distro_utils.EnableIpv6, 'enable')
+    mock_call.side_effect = [None, subprocess.CalledProcessError(1, 'Test')]
 
-      network_setup.NetworkSetup(['A', 'B'], debug=True)
-      expected_calls = [
-          mock.call.logger.Logger(name=mock.ANY, debug=True, facility=mock.ANY),
-      ]
-      self.assertEqual(mocks.mock_calls, expected_calls)
+    # Return immediately with no interfaces.
+    network_setup.NetworkSetup.EnableIpv6(self.setup, None)
+    network_setup.NetworkSetup.EnableIpv6(self.setup, [])
+    # Enable interfaces.
+    network_setup.NetworkSetup.EnableIpv6(
+        self.setup, ['A', 'B'])
+    self.assertEqual(self.setup.ipv6_interfaces, set(['A', 'B']))
+    # Add a new interface.
+    network_setup.NetworkSetup.EnableIpv6(
+        self.setup, ['A', 'B', 'C'])
+    self.assertEqual(self.setup.ipv6_interfaces, set(['A', 'B', 'C']))
+    # Interfaces are already enabled.
+    network_setup.NetworkSetup.EnableIpv6(
+        self.setup, ['A', 'B', 'C'])
+    self.assertEqual(self.setup.ipv6_interfaces, set(['A', 'B', 'C']))
+    expected_calls = [
+        mock.call.logger.info(mock.ANY, ['A', 'B']),
+        mock.call.enable(['A', 'B'], mock.ANY, dhclient_script='/bin/script'),
+        mock.call.logger.info(mock.ANY, ['A', 'B', 'C']),
+        mock.call.enable(
+            ['A', 'B', 'C'], mock.ANY, dhclient_script='/bin/script'),
+    ]
+    self.assertEqual(mocks.mock_calls, expected_calls)
 
   @mock.patch('google_compute_engine.networking.network_setup.network_setup.subprocess.check_call')
   def testEnableNetworkInterfaces(self, mock_call):
     mocks = mock.Mock()
     mocks.attach_mock(mock_call, 'call')
     mocks.attach_mock(self.mock_logger, 'logger')
-    mocks.attach_mock(
-        self.mock_setup.distro_utils.EnableNetworkInterfaces, 'enable')
+    mocks.attach_mock(self.mock_distro_utils.EnableNetworkInterfaces, 'enable')
     mock_call.side_effect = [None, subprocess.CalledProcessError(1, 'Test')]
 
-    # Return immediately with fewer than two interfaces.
-    network_setup.NetworkSetup.EnableNetworkInterfaces(self.mock_setup, None)
-    network_setup.NetworkSetup.EnableNetworkInterfaces(self.mock_setup, [])
+    # Return immediately with no interfaces.
+    network_setup.NetworkSetup.EnableNetworkInterfaces(self.setup, None)
+    network_setup.NetworkSetup.EnableNetworkInterfaces(self.setup, [])
     # Enable interfaces.
     network_setup.NetworkSetup.EnableNetworkInterfaces(
-        self.mock_setup, ['A', 'B'])
-    self.assertEqual(self.mock_setup.interfaces, set(['A', 'B']))
+        self.setup, ['A', 'B'])
+    self.assertEqual(self.setup.interfaces, set(['A', 'B']))
     # Add a new interface.
     network_setup.NetworkSetup.EnableNetworkInterfaces(
-        self.mock_setup, ['A', 'B', 'C'])
-    self.assertEqual(self.mock_setup.interfaces, set(['A', 'B', 'C']))
+        self.setup, ['A', 'B', 'C'])
+    self.assertEqual(self.setup.interfaces, set(['A', 'B', 'C']))
     # Interfaces are already enabled.
     network_setup.NetworkSetup.EnableNetworkInterfaces(
-        self.mock_setup, ['A', 'B', 'C'])
-    self.assertEqual(self.mock_setup.interfaces, set(['A', 'B', 'C']))
+        self.setup, ['A', 'B', 'C'])
+    self.assertEqual(self.setup.interfaces, set(['A', 'B', 'C']))
     # Run a user supplied command successfully.
-    self.mock_setup.dhcp_command = 'success'
+    self.setup.dhcp_command = 'success'
     network_setup.NetworkSetup.EnableNetworkInterfaces(
-        self.mock_setup, ['D', 'E'])
-    self.assertEqual(self.mock_setup.interfaces, set(['D', 'E']))
+        self.setup, ['D', 'E'])
+    self.assertEqual(self.setup.interfaces, set(['D', 'E']))
     # Run a user supplied command and logger error messages.
-    self.mock_setup.dhcp_command = 'failure'
+    self.setup.dhcp_command = 'failure'
     network_setup.NetworkSetup.EnableNetworkInterfaces(
-        self.mock_setup, ['F', 'G'])
-    self.assertEqual(self.mock_setup.interfaces, set(['F', 'G']))
+        self.setup, ['F', 'G'])
+    self.assertEqual(self.setup.interfaces, set(['F', 'G']))
     expected_calls = [
         mock.call.logger.info(mock.ANY, ['A', 'B']),
         mock.call.enable(['A', 'B'], mock.ANY, dhclient_script='/bin/script'),


### PR DESCRIPTION
Support for FreeBSD and SLES images is still needed.