### PR TITLE
Add user name validation to pam modules.

### DIFF
--- a/google_compute_engine_oslogin/pam_module/pam_oslogin_admin.cc
+++ b/google_compute_engine_oslogin/pam_module/pam_oslogin_admin.cc
@@ -34,6 +34,7 @@ using oslogin_utils::HttpGet;
 using oslogin_utils::ParseJsonToAuthorizeResponse;
 using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::UrlEncode;
+using oslogin_utils::ValidateUserName;
 using oslogin_utils::kMetadataServerUrl;
 
 static const char kSudoersDir[] = "/var/google-sudoers.d/";
@@ -51,6 +52,10 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc,
     return pam_result;
   }
   string str_user_name(user_name);
+  if (!ValidateUserName(user_name)) {
+    // If the user name is not a valid oslogin user, don't bother continuing.
+    return PAM_SUCCESS;
+  }
 
   std::stringstream url;
   url << kMetadataServerUrl

--- a/google_compute_engine_oslogin/pam_module/pam_oslogin_login.cc
+++ b/google_compute_engine_oslogin/pam_module/pam_oslogin_login.cc
@@ -34,6 +34,7 @@ using oslogin_utils::HttpGet;
 using oslogin_utils::ParseJsonToAuthorizeResponse;
 using oslogin_utils::ParseJsonToEmail;
 using oslogin_utils::UrlEncode;
+using oslogin_utils::ValidateUserName;
 using oslogin_utils::kMetadataServerUrl;
 
 static const char kUsersDir[] = "/var/google-users.d/";
@@ -49,6 +50,10 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc,
     return pam_result;
   }
   string str_user_name(user_name);
+  if (!ValidateUserName(user_name)) {
+    // If the user name is not a valid oslogin user, don't bother continuing.
+    return PAM_SUCCESS;
+  }
   string users_filename = kUsersDir;
   users_filename.append(user_name);
   struct stat buffer;

--- a/google_compute_engine_oslogin/utils/oslogin_utils.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.cc
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <iostream>
 #include <sstream>
+#include <regex>
 
 #include "oslogin_utils.h"
 
@@ -29,6 +30,9 @@ using std::string;
 
 // Maximum number of retries for HTTP requests.
 const int kMaxRetries = 1;
+
+// Regex for validating user names.
+const char kUserNameRegex[] = "^[a-zA-Z0-9._][a-zA-Z0-9._-]{0,31}$";
 
 namespace oslogin_utils {
 
@@ -220,6 +224,11 @@ bool HttpGet(const string& url, string* response, long* http_code) {
   curl_easy_cleanup(curl);
   curl_global_cleanup();
   return true;
+}
+
+bool ValidateUserName(const string& user_name) {
+  std::regex r(kUserNameRegex);
+  return std::regex_match(user_name, r);
 }
 
 string UrlEncode(const string& param) {

--- a/google_compute_engine_oslogin/utils/oslogin_utils.h
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.h
@@ -139,6 +139,9 @@ OnCurlWrite(void* buf, size_t size, size_t nmemb, void* userp);
 // stored in response, and the HTTP response code will be stored in http_code.
 bool HttpGet(const string& url, string* response, long* http_code);
 
+// Returns whether user_name is a valid OsLogin user name.
+bool ValidateUserName(const string& user_name);
+
 // URL encodes the given parameter. Returns the encoded parameter.
 std::string UrlEncode(const string& param);
 

--- a/google_compute_engine_oslogin/utils/oslogin_utils_test.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils_test.cc
@@ -164,6 +164,7 @@ TEST(NssCacheTest, TestLoadJsonFinalResponse) {
 
   // Verify that there are no more users stored.
   ASSERT_FALSE(nss_cache.HasNextPasswd());
+  ASSERT_TRUE(nss_cache.OnLastPage());
   ASSERT_FALSE(nss_cache.GetNextPasswd(&buf, &result, &test_errno));
   EXPECT_EQ(test_errno, ENOENT);
 }
@@ -426,6 +427,41 @@ TEST(ParseJsonSshKeyTest, ParseJsonToSshKeysFiltersMalformedExpiration) {
 TEST(ParseJsonAuthorizeSuccess, SuccessfullyAuthorized) {
   string response = "{\"success\": true}";
   ASSERT_TRUE(ParseJsonToAuthorizeResponse(response));
+}
+
+TEST(ValidateUserNameTest, ValidateValidUserNames) {
+  string cases[] = {
+      "user",
+      "_",
+      ".",
+      ".abc_",
+      "_abc-",
+      "ABC",
+      "A_.-",
+      "ausernamethirtytwocharacterslong"
+  };
+  for (auto test_user : cases) {
+    ASSERT_TRUE(ValidateUserName(test_user));
+  }
+}
+
+TEST(ValidateUserNameTest, ValidateInvalidUserNames) {
+  string cases[] = {
+      "",
+      "!#$%^",
+      "-abc",
+      "#abc",
+      "^abc",
+      "abc*xyz",
+      "abc xyz",
+      "xyz*",
+      "xyz$",
+      "usernamethirtythreecharacterslong",
+      "../../etc/shadow",
+  };
+  for (auto test_user : cases) {
+    ASSERT_FALSE(ValidateUserName(test_user));
+  }
 }
 
 }  // namespace oslogin_utils

--- a/google_compute_engine_oslogin/utils/run_tests.sh
+++ b/google_compute_engine_oslogin/utils/run_tests.sh
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 # Unit tests require gtest to be installed.
-g++ -o test_runner oslogin_utils_test.cc oslogin_utils.cc -I/usr/include/json-c -lcurl -ljson -lgtest -lpthread
+g++ -o test_runner oslogin_utils_test.cc oslogin_utils.cc -I/usr/include/json-c -lcurl -ljson-c -lgtest -lpthread
 ./test_runner
 rm ./test_runner


### PR DESCRIPTION
As extra insurance, have the pam modules perform user name validation.

Includes some cleanup in tests and test script.

Addresses issue #621 