### PR TITLE
tox.ini: Lint on Python 3, not on Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: true
 python:
 - 2.7
-- 3.3
+# - 3.3  # Tox no longer supports the EOLed Python 3.3
 - 3.4
 - 3.5
 - 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35,pypy,pypy3
+envlist = py26,py27,py32,py33,py34,py35,py36,pypy,pypy3
 
 [testenv]
 deps =
@@ -64,4 +64,4 @@ exclude =
 # See https://github.com/ryanhiebert/tox-travis#advanced-configuration
 [travis]
 python =
-  2.7: py27, lint
+  3.6: py36, lint


### PR DESCRIPTION
Python is much more strict than legacy Python so let’s try linting on the stricter platform.