### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
 - 3.5
 - 3.6
 - pypy
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial  # required for Python 3.7 (travis-ci/travis-ci#9069)
 os:
 - linux
 install:

--- a/google_compute_engine/accounts/oslogin_utils.py
+++ b/google_compute_engine/accounts/oslogin_utils.py
@@ -15,6 +15,7 @@
 
 """Utilities for provisioning or deprovisioning a Linux user account."""
 
+import errno
 import os
 import subprocess
 import time
@@ -50,7 +51,7 @@ class OsLoginUtils(object):
     try:
       return subprocess.call([constants.OSLOGIN_CONTROL_SCRIPT, action])
     except OSError as e:
-      if e.errno == os.errno.ENOENT:
+      if e.errno == errno.ENOENT:
         return None
       else:
         raise
@@ -83,7 +84,7 @@ class OsLoginUtils(object):
     try:
       return subprocess.call([constants.OSLOGIN_NSS_CACHE_SCRIPT])
     except OSError as e:
-      if e.errno == os.errno.ENOENT:
+      if e.errno == errno.ENOENT:
         return None
       else:
         raise
@@ -94,7 +95,7 @@ class OsLoginUtils(object):
       try:
         os.remove(constants.OSLOGIN_NSS_CACHE)
       except OSError as e:
-        if e.errno != os.errno.ENOENT:
+        if e.errno != errno.ENOENT:
           raise
 
   def UpdateOsLogin(self, enable, duration=NSS_CACHE_DURATION_SEC):

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Installation/Setup',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35,pypy,pypy3
+envlist = py26,py27,py32,py33,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 deps =
-    py{35,36}: distro
+    py{35,py36,py37}: distro
     setuptools>=20
     pytest
     pytest-cov
@@ -64,4 +64,4 @@ exclude =
 # See https://github.com/ryanhiebert/tox-travis#advanced-configuration
 [travis]
 python =
-  2.7: py27, lint
+  3.6: py36, lint


### PR DESCRIPTION
* Add Python 3.7 to the testing In alignment with travis-ci/travis-ci#9069
* Lint on Python 3 instead of Python 2 because it is stricter.
* Fixed __os.errno__ --> __errno__ as discussed on the last bullet of:
    * https://docs.python.org/3/whatsnew/3.7.html#changes-in-the-python-api