### PR TITLE
oslogin: fix compiling error in regex for gcc < 4.9

### DIFF
--- a/google_compute_engine_oslogin/packaging/rpmbuild/SPECS/google-compute-engine-oslogin.spec
+++ b/google_compute_engine_oslogin/packaging/rpmbuild/SPECS/google-compute-engine-oslogin.spec
@@ -25,12 +25,14 @@ Summary:        OS Login Functionality for Google Compute Engine
 License:        ASL 2.0
 Source0:        %{name}_%{version}.orig.tar.gz
 
+BuildRequires:  boost-devel
 BuildRequires:  gcc-c++
 BuildRequires:  make
 BuildRequires:  libcurl
 BuildRequires:  json-c
 BuildRequires:  pam-devel
 BuildRequires:  policycoreutils-python
+Requires:  boost-regex
 Requires:  policycoreutils-python
 
 %define pam_install_path /%{_lib}/security
@@ -43,7 +45,7 @@ for Google Compute Engine.
 %setup
 
 %build
-make %{?_smp_mflags} LIBS="-lcurl -ljson-c"
+make %{?_smp_mflags} LIBS="-lcurl -ljson-c -lboost_regex"
 
 %install
 rm -rf %{buildroot}

--- a/google_compute_engine_oslogin/utils/oslogin_utils.cc
+++ b/google_compute_engine_oslogin/utils/oslogin_utils.cc
@@ -22,7 +22,19 @@
 #include <cstring>
 #include <iostream>
 #include <sstream>
+
+#ifdef __GNUC__
+#if __GNUC__ > 4 || \
+  (__GNUC__ == 4 && (__GNUC_MINOR__ > 9 || \
+                     (__GNUC_MINOR__ == 9 && \
+                      __GNUC_PATCHLEVEL__ > 0)))
 #include <regex>
+#define Regex std
+#else
+#include <boost/regex.hpp>
+#define Regex boost
+#endif
+#endif
 
 #include "oslogin_utils.h"
 
@@ -227,8 +239,8 @@ bool HttpGet(const string& url, string* response, long* http_code) {
 }
 
 bool ValidateUserName(const string& user_name) {
-  std::regex r(kUserNameRegex);
-  return std::regex_match(user_name, r);
+  Regex::regex r(kUserNameRegex);
+  return Regex::regex_match(user_name, r);
 }
 
 string UrlEncode(const string& param) {


### PR DESCRIPTION
rhel7 uses GCC 4.8 and rhel6 uses gcc4.4 and they don't have support for regex

Fixes #650