### PR TITLE
Remove users from the sudoers group on removal.

### DIFF
--- a/google_compute_engine/accounts/accounts_utils.py
+++ b/google_compute_engine/accounts/accounts_utils.py
@@ -27,6 +27,7 @@ from google_compute_engine import constants
 from google_compute_engine import file_utils
 
 USER_REGEX = re.compile(r'\A[A-Za-z0-9._][A-Za-z0-9._-]{0,31}\Z')
+DEFAULT_GPASSWD_CMD = 'gpasswd -d {user} {group}'
 DEFAULT_GROUPADD_CMD = 'groupadd {group}'
 DEFAULT_USERADD_CMD = 'useradd -m -s /bin/bash -p * {user}'
 DEFAULT_USERDEL_CMD = 'userdel -r {user}'
@@ -39,19 +40,21 @@ class AccountsUtils(object):
   google_comment = '# Added by Google'
 
   def __init__(
-      self, logger, groups=None, remove=False, groupadd_cmd=None,
-      useradd_cmd=None, userdel_cmd=None, usermod_cmd=None):
+      self, logger, groups=None, remove=False, gpasswd_cmd=None,
+      groupadd_cmd=None, useradd_cmd=None, userdel_cmd=None, usermod_cmd=None):
     """Constructor.
 
     Args:
       logger: logger object, used to write to SysLog and serial port.
       groups: string, a comma separated list of groups.
       remove: bool, True if deprovisioning a user should be destructive.
+      gpasswd_cmd: string, command to remove a user from a group.
       groupadd_cmd: string, command to add a new group.
       useradd_cmd: string, command to create a new user.
       userdel_cmd: string, command to delete a user.
       usermod_cmd: string, command to modify user's groups.
     """
+    self.gpasswd_cmd = gpasswd_cmd or DEFAULT_GPASSWD_CMD
     self.groupadd_cmd = groupadd_cmd or DEFAULT_GROUPADD_CMD
     self.useradd_cmd = useradd_cmd or DEFAULT_USERADD_CMD
     self.userdel_cmd = userdel_cmd or DEFAULT_USERDEL_CMD
@@ -242,6 +245,27 @@ class AccountsUtils(object):
     file_utils.SetPermissions(
         authorized_keys_file, mode=0o600, uid=uid, gid=gid)
 
+  def _RemoveSudoer(self, user):
+    """Remove a Linux user account from the sudoers group.
+
+    Args:
+      user: string, the name of the Linux user account.
+
+    Returns:
+      bool, True if user update succeeded.
+    """
+    self.logger.debug('Removing user %s from the Google sudoers group.', user)
+    command = self.gpasswd_cmd.format(
+        user=user, group=self.google_sudoers_group)
+    try:
+      subprocess.check_call(command.split(' '))
+    except subprocess.CalledProcessError as e:
+      self.logger.warning('Could not update user %s. %s.', user, str(e))
+      return False
+    else:
+      self.logger.debug('Removed user %s from the Google sudoers group.', user)
+      return True
+
   def _RemoveAuthorizedKeys(self, user):
     """Remove a Linux user account's authorized keys file to prevent login.
 
@@ -337,6 +361,7 @@ class AccountsUtils(object):
       user: string, the Linux user account to remove.
     """
     self.logger.info('Removing user %s.', user)
+    self._RemoveSudoer(user)
     if self.remove:
       command = self.userdel_cmd.format(user=user)
       try:

--- a/google_compute_engine/accounts/tests/accounts_utils_test.py
+++ b/google_compute_engine/accounts/tests/accounts_utils_test.py
@@ -31,10 +31,11 @@ class AccountsUtilsTest(unittest.TestCase):
     self.sudoers_file = '/sudoers/file'
     self.users_dir = '/users'
     self.users_file = '/users/file'
+    self.gpasswd_cmd = 'useradd -m -s /bin/bash -p * {user}'
+    self.groupadd_cmd = 'groupadd {group}'
     self.useradd_cmd = 'useradd -m -s /bin/bash -p * {user}'
     self.userdel_cmd = 'userdel -r {user}'
     self.usermod_cmd = 'usermod -G {groups} {user}'
-    self.groupadd_cmd = 'groupadd {group}'
 
     self.mock_utils = mock.create_autospec(accounts_utils.AccountsUtils)
     self.mock_utils.google_comment = accounts_utils.AccountsUtils.google_comment
@@ -43,10 +44,11 @@ class AccountsUtilsTest(unittest.TestCase):
     self.mock_utils.google_users_dir = self.users_dir
     self.mock_utils.google_users_file = self.users_file
     self.mock_utils.logger = self.mock_logger
+    self.mock_utils.gpasswd_cmd = self.gpasswd_cmd
+    self.mock_utils.groupadd_cmd = self.groupadd_cmd
     self.mock_utils.useradd_cmd = self.useradd_cmd
     self.mock_utils.userdel_cmd = self.userdel_cmd
     self.mock_utils.usermod_cmd = self.usermod_cmd
-    self.mock_utils.groupadd_cmd = self.groupadd_cmd
 
   @mock.patch('google_compute_engine.accounts.accounts_utils.AccountsUtils._GetGroup')
   @mock.patch('google_compute_engine.accounts.accounts_utils.AccountsUtils._CreateSudoersGroup')
@@ -428,6 +430,35 @@ class AccountsUtilsTest(unittest.TestCase):
     self.mock_logger.warning.assert_called_once_with(mock.ANY, user)
     mock_permissions.assert_not_called()
 
+  @mock.patch('google_compute_engine.accounts.accounts_utils.subprocess.check_call')
+  def testRemoveSudoer(self, mock_call):
+    user = 'user'
+    command = self.usermod_cmd.format(user=user, groups=self.sudoers_group)
+
+    self.assertTrue(
+        accounts_utils.AccountsUtils._RemoveSudoer(self.mock_utils, user))
+    mock.call.assert_called_once_with(command.split(' ')),
+    expected_calls = [
+        mock.call.debug(mock.ANY, user),
+        mock.call.debug(mock.ANY, user),
+    ]
+    self.assertEqual(self.mock_logger.mock_calls, expected_calls)
+
+  @mock.patch('google_compute_engine.accounts.accounts_utils.subprocess.check_call')
+  def testRemoveSudoerError(self, mock_call):
+    user = 'user'
+    command = self.usermod_cmd.format(user=user, groups=self.sudoers_group)
+    mock_call.side_effect = subprocess.CalledProcessError(1, 'Test')
+
+    self.assertFalse(
+        accounts_utils.AccountsUtils._RemoveSudoer(self.mock_utils, user))
+    mock.call.assert_called_once_with(command.split(' ')),
+    expected_calls = [
+        mock.call.debug(mock.ANY, user),
+        mock.call.warning(mock.ANY, user, mock.ANY),
+    ]
+    self.assertEqual(self.mock_logger.mock_calls, expected_calls)
+
   @mock.patch('google_compute_engine.accounts.accounts_utils.os.remove')
   @mock.patch('google_compute_engine.accounts.accounts_utils.os.path.exists')
   def testRemoveAuthorizedKeys(self, mock_exists, mock_remove):
@@ -642,6 +673,7 @@ class AccountsUtilsTest(unittest.TestCase):
     self.mock_utils.remove = False
 
     accounts_utils.AccountsUtils.RemoveUser(self.mock_utils, user)
+    self.mock_utils._RemoveSudoer.assert_called_once_with(user)
     self.mock_utils._RemoveAuthorizedKeys.assert_called_once_with(user)
     mock_call.assert_not_called()
 
@@ -655,6 +687,7 @@ class AccountsUtilsTest(unittest.TestCase):
     mock.call.assert_called_once_with(command.split(' ')),
     expected_calls = [mock.call.info(mock.ANY, user)] * 2
     self.assertEqual(self.mock_logger.mock_calls, expected_calls)
+    self.mock_utils._RemoveSudoer.assert_called_once_with(user)
     self.mock_utils._RemoveAuthorizedKeys.assert_called_once_with(user)
 
   @mock.patch('google_compute_engine.accounts.accounts_utils.subprocess.check_call')
@@ -671,6 +704,7 @@ class AccountsUtilsTest(unittest.TestCase):
         mock.call.warning(mock.ANY, user, mock.ANY),
     ]
     self.assertEqual(self.mock_logger.mock_calls, expected_calls)
+    self.mock_utils._RemoveSudoer.assert_called_once_with(user)
     self.mock_utils._RemoveAuthorizedKeys.assert_called_once_with(user)
 
 


### PR DESCRIPTION
This prevents the local user account from having elevated privileges
when used by OS Login.