### PR TITLE
Read gpasswd_cmd from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Accounts          | groups                 | Comma separated list of groups for 
 Accounts          | useradd\_cmd           | Command string to create a new user.
 Accounts          | userdel\_cmd           | Command string to delete a user.
 Accounts          | usermod\_cmd           | Command string to modify a user's groups.
+Accounts          | gpasswd\_cmd           | Command string to remove a user from a group.
 Accounts          | groupadd\_cmd          | Command string to create a new group.
 Daemons           | accounts\_daemon       | `false` disables the accounts daemon.
 Daemons           | clock\_skew\_daemon    | `false` disables the clock skew daemon.

--- a/google_compute_engine/accounts/accounts_daemon.py
+++ b/google_compute_engine/accounts/accounts_daemon.py
@@ -39,8 +39,8 @@ class AccountsDaemon(object):
   user_ssh_keys = {}
 
   def __init__(
-      self, groups=None, remove=False, useradd_cmd=None, userdel_cmd=None,
-      usermod_cmd=None, groupadd_cmd=None, debug=False):
+      self, groups=None, remove=False, gpasswd_cmd=None, groupadd_cmd=None,
+      useradd_cmd=None, userdel_cmd=None, usermod_cmd=None, debug=False):
     """Constructor.
 
     Args:
@@ -50,6 +50,7 @@ class AccountsDaemon(object):
       userdel_cmd: string, command to delete a user.
       usermod_cmd: string, command to modify user's groups.
       groupadd_cmd: string, command to add a new group.
+      gpasswd_cmd: string, command to remove a user from a group.
       debug: bool, True if debug output should write to the console.
     """
     facility = logging.handlers.SysLogHandler.LOG_DAEMON
@@ -58,8 +59,9 @@ class AccountsDaemon(object):
     self.watcher = metadata_watcher.MetadataWatcher(logger=self.logger)
     self.utils = accounts_utils.AccountsUtils(
         logger=self.logger, groups=groups, remove=remove,
+        gpasswd_cmd=gpasswd_cmd, groupadd_cmd=groupadd_cmd,
         useradd_cmd=useradd_cmd, userdel_cmd=userdel_cmd,
-        usermod_cmd=usermod_cmd, groupadd_cmd=groupadd_cmd)
+        usermod_cmd=usermod_cmd)
     self.oslogin = oslogin_utils.OsLoginUtils(logger=self.logger)
 
     try:
@@ -279,6 +281,7 @@ def main():
         usermod_cmd=instance_config.GetOptionString('Accounts', 'usermod_cmd'),
         groupadd_cmd=instance_config.GetOptionString(
             'Accounts', 'groupadd_cmd'),
+        gpasswd_cmd=instance_config.GetOptionString('Accounts', 'gpasswd_cmd'),
         debug=bool(options.debug))
 
 

--- a/google_compute_engine/accounts/tests/accounts_daemon_test.py
+++ b/google_compute_engine/accounts/tests/accounts_daemon_test.py
@@ -57,8 +57,8 @@ class AccountsDaemonTest(unittest.TestCase):
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.AccountsUtils(
               logger=mock_logger_instance, groups='foo,bar', remove=True,
-              useradd_cmd=mock.ANY, userdel_cmd=mock.ANY, usermod_cmd=mock.ANY,
-              groupadd_cmd=mock.ANY),
+              gpasswd_cmd=mock.ANY, groupadd_cmd=mock.ANY, useradd_cmd=mock.ANY,
+              userdel_cmd=mock.ANY, usermod_cmd=mock.ANY),
           mock.call.lock.LockFile(accounts_daemon.LOCKFILE),
           mock.call.lock.LockFile().__enter__(),
           mock.call.logger.Logger().info(mock.ANY),
@@ -90,8 +90,8 @@ class AccountsDaemonTest(unittest.TestCase):
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.AccountsUtils(
               logger=mock_logger_instance, groups=None, remove=False,
-              useradd_cmd=mock.ANY, userdel_cmd=mock.ANY, usermod_cmd=mock.ANY,
-              groupadd_cmd=mock.ANY),
+              gpasswd_cmd=mock.ANY, groupadd_cmd=mock.ANY, useradd_cmd=mock.ANY,
+              userdel_cmd=mock.ANY, usermod_cmd=mock.ANY),
           mock.call.lock.LockFile(accounts_daemon.LOCKFILE),
           mock.call.logger.Logger().warning('Test Error'),
       ]

--- a/google_compute_engine/instance_setup/instance_config.py
+++ b/google_compute_engine/instance_setup/instance_config.py
@@ -58,6 +58,7 @@ class InstanceConfig(config_manager.ConfigManager):
           #
           # To solve the issue, make the password '*' which is also recognized
           # as locked but does not prevent SSH login.
+          'gpasswd_cmd': 'gpasswd -d {user} {group}',
           'groupadd_cmd': 'groupadd {group}',
           'useradd_cmd': 'useradd -m -s /bin/bash -p * {user}',
           'userdel_cmd': 'userdel -r {user}',


### PR DESCRIPTION
With this we can configure the specific FreeBSD command
to remove an user from a group enabling the sudoers removal
feature in it.