### PR TITLE
Add journald config to forward logs to console

### DIFF
--- a/google_config/journald/20-google.conf
+++ b/google_config/journald/20-google.conf
@@ -1,0 +1,4 @@
+# Google Compute Engine default console logging.
+
+[Journal]
+ForwardToConsole=yes


### PR DESCRIPTION
This is an alternative to rsyslog for systems that runs systemd.

I executed the image tests with this new config instead of rsyslog one and it worked.