### PR TITLE
google_compute_engine: Add Fedora support to compat module

### DIFF
--- a/google_compute_engine/compat.py
+++ b/google_compute_engine/compat.py
@@ -40,6 +40,8 @@ elif 'red hat enterprise linux' in distro_name and distro_version == '6':
   import google_compute_engine.distro_lib.el_6.utils as distro_utils
 elif 'red hat enterprise linux' in distro_name:
   import google_compute_engine.distro_lib.el_7.utils as distro_utils
+elif 'fedora' in distro_name:
+  import google_compute_engine.distro_lib.el_7.utils as distro_utils
 elif 'debian' in distro_name and distro_version == '8':
   import google_compute_engine.distro_lib.debian_8.utils as distro_utils
 elif 'debian' in distro_name:

--- a/google_compute_engine/tests/compat_test.py
+++ b/google_compute_engine/tests/compat_test.py
@@ -71,6 +71,8 @@ class CompatTest(unittest.TestCase):
   @mock.patch('google_compute_engine.compat.distro.linux_distribution')
   def testDistroCompatLinux(self, mock_call):
     test_cases = {
+        ('Fedora', '28', ''):
+            google_compute_engine.distro_lib.el_7.utils,
         ('debian', '8.10', ''):
             google_compute_engine.distro_lib.debian_8.utils,
         ('debian', '9.3', ''):


### PR DESCRIPTION
For all intents and purposes, we can pretend Fedora works like Enterprise Linux 7 systems, such as Red Hat Enterprise Linux and CentOS.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>