### PR TITLE
google-network-daemon: Start before cloud-init runs

### DIFF
--- a/google_compute_engine_init/systemd/google-network-daemon.service
+++ b/google_compute_engine_init/systemd/google-network-daemon.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Google Compute Engine Network Daemon
+Before=cloud-init.service
 After=local-fs.target network-online.target network.target rsyslog.service
 After=google-instance-setup.service
 Wants=local-fs.target network-online.target network.target


### PR DESCRIPTION
The systemd `PartOf=` declaration here isn't enough to make cloud-init wait for the service to finish configuration, so we ensure that this runs before cloud-init is started to configure the network properly.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>