### PR TITLE
Adds support for oslogin on Arch Linux.

### DIFF
--- a/packages/google-compute-engine-oslogin/bin/google_oslogin_control
+++ b/packages/google-compute-engine-oslogin/bin/google_oslogin_control
@@ -173,6 +173,9 @@ modify_pam_sshd() (
   elif [ -e /etc/os-release ] && grep -q 'ID="sles"' /etc/os-release; then
     # Get location of common-auth.
     insert=$($sed -rn "/^auth\s+include\s+common-auth/=" "$pam_config")
+  elif [ -e /etc/arch-release ]; then
+    # Get location of system-remote-login.
+    insert=$($sed -rn "/^auth\s+include\s+system-remote-login/=" "$pam_config")
   fi
 
   added_config="$added_comment"


### PR DESCRIPTION
Arch Linux PAM configuration file for sshd is just a redirect to a common
system-login configuration.  This switches the activation script to patch that
instead.