### PR TITLE
pam_oslogin_login.cc: use str_user_name instead of user_name

### DIFF
--- a/google_compute_engine_oslogin/pam_module/pam_oslogin_login.cc
+++ b/google_compute_engine_oslogin/pam_module/pam_oslogin_login.cc
@@ -144,7 +144,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
 
   // System accounts begin with the prefix `sa_`.
   string sa_prefix = "sa_";
-  if (user_name.compare(0, sa_prefix.size(), sa_prefix) == 0) {
+  if (str_user_name.compare(0, sa_prefix.size(), sa_prefix) == 0) {
     return PAM_SUCCESS;
   }
 


### PR DESCRIPTION
user_name is a 'const char *' and does not have the compare() function
called which leads to a compilation error.