### PR TITLE
Fix the default gpasswd_cmd in the config file.

### DIFF
--- a/google_compute_engine/instance_setup/instance_config.py
+++ b/google_compute_engine/instance_setup/instance_config.py
@@ -58,7 +58,7 @@ class InstanceConfig(config_manager.ConfigManager):
           #
           # To solve the issue, make the password '*' which is also recognized
           # as locked but does not prevent SSH login.
-          'gpasswd_cmd': 'gpasswd -d {user} {group}',
+          'gpasswd_cmd': 'gpasswd {option} {user} {group}',
           'groupadd_cmd': 'groupadd {group}',
           'useradd_cmd': 'useradd -m -s /bin/bash -p * {user}',
           'userdel_cmd': 'userdel -r {user}',


### PR DESCRIPTION
The gpasswd command takes in an optional argument.

Fixes bug introduced by #658.