### PR TITLE
Accounts: separate gpasswd command in two

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ Accounts          | groups                 | Comma separated list of groups for 
 Accounts          | useradd\_cmd           | Command string to create a new user.
 Accounts          | userdel\_cmd           | Command string to delete a user.
 Accounts          | usermod\_cmd           | Command string to modify a user's groups.
-Accounts          | gpasswd\_cmd           | Command string to remove a user from a group.
+Accounts          | gpasswd\_add\_cmd      | Command string to add an user to a group.
+Accounts          | gpasswd\_remove\_cmd   | Command string to remove an user from a group.
 Accounts          | groupadd\_cmd          | Command string to create a new group.
 Daemons           | accounts\_daemon       | `false` disables the accounts daemon.
 Daemons           | clock\_skew\_daemon    | `false` disables the clock skew daemon.

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ Accounts          | groups                 | Comma separated list of groups for 
 Accounts          | useradd\_cmd           | Command string to create a new user.
 Accounts          | userdel\_cmd           | Command string to delete a user.
 Accounts          | usermod\_cmd           | Command string to modify a user's groups.
-Accounts          | gpasswd\_add\_cmd      | Command string to add an user to a group.
-Accounts          | gpasswd\_remove\_cmd   | Command string to remove an user from a group.
+Accounts          | gpasswd\_add\_cmd      | Command string to add a user to a group.
+Accounts          | gpasswd\_remove\_cmd   | Command string to remove a user from a group.
 Accounts          | groupadd\_cmd          | Command string to create a new group.
 Daemons           | accounts\_daemon       | `false` disables the accounts daemon.
 Daemons           | clock\_skew\_daemon    | `false` disables the clock skew daemon.

--- a/google_compute_engine/accounts/accounts_daemon.py
+++ b/google_compute_engine/accounts/accounts_daemon.py
@@ -39,8 +39,9 @@ class AccountsDaemon(object):
   user_ssh_keys = {}
 
   def __init__(
-      self, groups=None, remove=False, gpasswd_cmd=None, groupadd_cmd=None,
-      useradd_cmd=None, userdel_cmd=None, usermod_cmd=None, debug=False):
+      self, groups=None, remove=False, gpasswd_add_cmd=None,
+      gpasswd_remove_cmd=None, groupadd_cmd=None, useradd_cmd=None,
+      userdel_cmd=None, usermod_cmd=None, debug=False):
     """Constructor.
 
     Args:
@@ -50,7 +51,8 @@ class AccountsDaemon(object):
       userdel_cmd: string, command to delete a user.
       usermod_cmd: string, command to modify user's groups.
       groupadd_cmd: string, command to add a new group.
-      gpasswd_cmd: string, command to remove a user from a group.
+      gpasswd_add_cmd: string, command to add an user to a group.
+      gpasswd_remove_cmd: string, command to remove an user from a group.
       debug: bool, True if debug output should write to the console.
     """
     facility = logging.handlers.SysLogHandler.LOG_DAEMON
@@ -59,9 +61,9 @@ class AccountsDaemon(object):
     self.watcher = metadata_watcher.MetadataWatcher(logger=self.logger)
     self.utils = accounts_utils.AccountsUtils(
         logger=self.logger, groups=groups, remove=remove,
-        gpasswd_cmd=gpasswd_cmd, groupadd_cmd=groupadd_cmd,
-        useradd_cmd=useradd_cmd, userdel_cmd=userdel_cmd,
-        usermod_cmd=usermod_cmd)
+        gpasswd_add_cmd=gpasswd_add_cmd, gpasswd_remove_cmd=gpasswd_remove_cmd,
+        groupadd_cmd=groupadd_cmd, useradd_cmd=useradd_cmd,
+        userdel_cmd=userdel_cmd, usermod_cmd=usermod_cmd)
     self.oslogin = oslogin_utils.OsLoginUtils(logger=self.logger)
 
     try:
@@ -299,7 +301,8 @@ def main():
         usermod_cmd=instance_config.GetOptionString('Accounts', 'usermod_cmd'),
         groupadd_cmd=instance_config.GetOptionString(
             'Accounts', 'groupadd_cmd'),
-        gpasswd_cmd=instance_config.GetOptionString('Accounts', 'gpasswd_cmd'),
+        gpasswd_add_cmd=instance_config.GetOptionString('Accounts', 'gpasswd_add_cmd'),
+        gpasswd_remove_cmd=instance_config.GetOptionString('Accounts', 'gpasswd_remove_cmd'),
         debug=bool(options.debug))
 
 

--- a/google_compute_engine/accounts/tests/accounts_daemon_test.py
+++ b/google_compute_engine/accounts/tests/accounts_daemon_test.py
@@ -57,7 +57,8 @@ class AccountsDaemonTest(unittest.TestCase):
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.AccountsUtils(
               logger=mock_logger_instance, groups='foo,bar', remove=True,
-              gpasswd_cmd=mock.ANY, groupadd_cmd=mock.ANY, useradd_cmd=mock.ANY,
+              gpasswd_add_cmd=mock.ANY, gpasswd_remove_cmd=mock.ANY,
+              groupadd_cmd=mock.ANY, useradd_cmd=mock.ANY,
               userdel_cmd=mock.ANY, usermod_cmd=mock.ANY),
           mock.call.lock.LockFile(accounts_daemon.LOCKFILE),
           mock.call.lock.LockFile().__enter__(),
@@ -90,7 +91,8 @@ class AccountsDaemonTest(unittest.TestCase):
           mock.call.watcher.MetadataWatcher(logger=mock_logger_instance),
           mock.call.utils.AccountsUtils(
               logger=mock_logger_instance, groups=None, remove=False,
-              gpasswd_cmd=mock.ANY, groupadd_cmd=mock.ANY, useradd_cmd=mock.ANY,
+              gpasswd_add_cmd=mock.ANY, gpasswd_remove_cmd=mock.ANY,
+              groupadd_cmd=mock.ANY, useradd_cmd=mock.ANY,
               userdel_cmd=mock.ANY, usermod_cmd=mock.ANY),
           mock.call.lock.LockFile(accounts_daemon.LOCKFILE),
           mock.call.logger.Logger().warning('Test Error'),

--- a/google_compute_engine/accounts/tests/accounts_utils_test.py
+++ b/google_compute_engine/accounts/tests/accounts_utils_test.py
@@ -31,7 +31,8 @@ class AccountsUtilsTest(unittest.TestCase):
     self.sudoers_file = '/sudoers/file'
     self.users_dir = '/users'
     self.users_file = '/users/file'
-    self.gpasswd_cmd = 'gpasswd {option} {user} {group}'
+    self.gpasswd_add_cmd = 'gpasswd -a {user} {group}'
+    self.gpasswd_remove_cmd = 'gpasswd -d {user} {group}'
     self.groupadd_cmd = 'groupadd {group}'
     self.useradd_cmd = 'useradd -m -s /bin/bash -p * {user}'
     self.userdel_cmd = 'userdel -r {user}'
@@ -44,7 +45,8 @@ class AccountsUtilsTest(unittest.TestCase):
     self.mock_utils.google_users_dir = self.users_dir
     self.mock_utils.google_users_file = self.users_file
     self.mock_utils.logger = self.mock_logger
-    self.mock_utils.gpasswd_cmd = self.gpasswd_cmd
+    self.mock_utils.gpasswd_add_cmd = self.gpasswd_add_cmd
+    self.mock_utils.gpasswd_remove_cmd = self.gpasswd_remove_cmd
     self.mock_utils.groupadd_cmd = self.groupadd_cmd
     self.mock_utils.useradd_cmd = self.useradd_cmd
     self.mock_utils.userdel_cmd = self.userdel_cmd
@@ -433,8 +435,8 @@ class AccountsUtilsTest(unittest.TestCase):
   @mock.patch('google_compute_engine.accounts.accounts_utils.subprocess.check_call')
   def testUpdateSudoer(self, mock_call):
     user = 'user'
-    command = self.gpasswd_cmd.format(
-        option='-d', user=user, group=self.sudoers_group)
+    command = self.gpasswd_remove_cmd.format(
+        user=user, group=self.sudoers_group)
 
     self.assertTrue(
         accounts_utils.AccountsUtils._UpdateSudoer(self.mock_utils, user))
@@ -448,8 +450,8 @@ class AccountsUtilsTest(unittest.TestCase):
   @mock.patch('google_compute_engine.accounts.accounts_utils.subprocess.check_call')
   def testUpdateSudoerAddSudoer(self, mock_call):
     user = 'user'
-    command = self.gpasswd_cmd.format(
-        option='-a', user=user, group=self.sudoers_group)
+    command = self.gpasswd_add_cmd.format(
+        user=user, group=self.sudoers_group)
 
     self.assertTrue(
         accounts_utils.AccountsUtils._UpdateSudoer(

--- a/google_compute_engine/accounts/tests/accounts_utils_test.py
+++ b/google_compute_engine/accounts/tests/accounts_utils_test.py
@@ -450,8 +450,7 @@ class AccountsUtilsTest(unittest.TestCase):
   @mock.patch('google_compute_engine.accounts.accounts_utils.subprocess.check_call')
   def testUpdateSudoerAddSudoer(self, mock_call):
     user = 'user'
-    command = self.gpasswd_add_cmd.format(
-        user=user, group=self.sudoers_group)
+    command = self.gpasswd_add_cmd.format(user=user, group=self.sudoers_group)
 
     self.assertTrue(
         accounts_utils.AccountsUtils._UpdateSudoer(

--- a/google_compute_engine/instance_setup/instance_config.py
+++ b/google_compute_engine/instance_setup/instance_config.py
@@ -58,7 +58,8 @@ class InstanceConfig(config_manager.ConfigManager):
           #
           # To solve the issue, make the password '*' which is also recognized
           # as locked but does not prevent SSH login.
-          'gpasswd_cmd': 'gpasswd {option} {user} {group}',
+          'gpasswd_add_cmd': 'gpasswd -a {user} {group}',
+          'gpasswd_remove_cmd': 'gpasswd -d {user} {group}',
           'groupadd_cmd': 'groupadd {group}',
           'useradd_cmd': 'useradd -m -s /bin/bash -p * {user}',
           'userdel_cmd': 'userdel -r {user}',


### PR DESCRIPTION
Specify different commands to add and remove users from a group.
In FreeBSD, the flags used by pw utility are not the same used
by gpasswd.