### PR TITLE
Set `oom_score_adj` for google-accounts-daemon

### DIFF
--- a/packages/google-compute-engine/src/etc/init/google-accounts-daemon.conf
+++ b/packages/google-compute-engine/src/etc/init/google-accounts-daemon.conf
@@ -1,5 +1,6 @@
 # Manages accounts from metadata SSH keys.
 start on started google-network-daemon
+oom -16
 
 respawn
 exec /usr/bin/google_accounts_daemon

--- a/packages/google-compute-engine/src/lib/systemd/system/google-accounts-daemon.service
+++ b/packages/google-compute-engine/src/lib/systemd/system/google-accounts-daemon.service
@@ -6,6 +6,7 @@ Requires=network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/google_accounts_daemon
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The google-accounts-daemon service is in the SSH login path and therefore should be a last choice for OOM killer. There is otherwise a slight chance of OOM killer making login impossible for new users.

Add relevant config lines to systemd and upstart service unit/job files.