### PR TITLE
Make script_retriever.py supports python 3

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
@@ -86,7 +86,7 @@ class ScriptRetriever(object):
       self.logger.warning('Could not download %s. %s.', url, str(e))
       return None
 
-    with open(dest, 'w') as f:
+    with open(dest, 'wb') as f:
       f.write(content)
 
     return dest

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
@@ -63,7 +63,7 @@ class ScriptRetrieverTest(unittest.TestCase):
     urlopen_read = mock_urlopen().read(return_value='foo')
     self.mock_logger.warning.assert_not_called()
 
-    mock_open.assert_called_once_with(self.dest, 'w')
+    mock_open.assert_called_once_with(self.dest, 'wb')
     handle = mock_open()
     handle.write.assert_called_once_with(urlopen_read)
 


### PR DESCRIPTION
Using python 3, the content returned by the urlrequest are bytes instead of
string. In order to write the content in a file the binary mode was added.