### PR TITLE
Restrict permissions for google-oslogin sudoers file

### DIFF
--- a/packages/google-compute-engine-oslogin/bin/google_oslogin_control
+++ b/packages/google-compute-engine-oslogin/bin/google_oslogin_control
@@ -294,6 +294,7 @@ setup_google_dirs() {
     fi
   done
   echo "#includedir ${sudoers_dir}" > "$sudoers_file"
+  chmod 0440 "$sudoers_file"
 }
 
 remove_google_dirs() {


### PR DESCRIPTION
File is created (via redirection) with default permissions, typically 0644. Added `chmod` to 0440.