### PR TITLE
Also chmod 0440 for managed sudoers files

### DIFF
--- a/packages/google-compute-engine-oslogin/pam_module/pam_oslogin_admin.cc
+++ b/packages/google-compute-engine-oslogin/pam_module/pam_oslogin_admin.cc
@@ -90,7 +90,7 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc,
                    << "\n";
       sudoers_file.close();
       chown(filename.c_str(), 0, 0);
-      chmod(filename.c_str(), S_IRUSR | S_IWUSR | S_IRGRP);
+      chmod(filename.c_str(), S_IRUSR | S_IRGRP);
     }
   } else if (file_exists) {
     remove(filename.c_str());


### PR DESCRIPTION
On reflection, we should also chmod 0440 the individual OS Login sudoers files.

visudo check passes:
```
liamh_google_com@debian-9:~$ sudo visudo --check                          
/etc/sudoers: parsed OK
/etc/sudoers.d/README: parsed OK
/etc/sudoers.d/google-oslogin: parsed OK
/var/google-sudoers.d/liamh_google_com: parsed OK
/etc/sudoers.d/google_sudoers: parsed OK
```