### PR TITLE
Update script retrieval to support Python 3.

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
@@ -81,7 +81,7 @@ class ScriptRetriever(object):
       request = urlrequest.Request(url)
       request.add_unredirected_header('Metadata-Flavor', 'Google')
       request.add_unredirected_header('Authorization', self.token)
-      content = urlrequest.urlopen(request).read()
+      content = urlrequest.urlopen(request).read().decode('utf-8')
     except (httpclient.HTTPException, socket.error, urlerror.URLError) as e:
       self.logger.warning('Could not download %s. %s.', url, str(e))
       return None

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
@@ -60,7 +60,7 @@ class ScriptRetrieverTest(unittest.TestCase):
     mocked_request.add_unredirected_header.assert_called_with(
         'Authorization', 'bar')
     mock_urlopen.assert_called_with(mocked_request)
-    urlopen_read = mock_urlopen().read(return_value='foo')
+    urlopen_read = mock_urlopen().read(return_value=b'foo').decode()
     self.mock_logger.warning.assert_not_called()
 
     mock_open.assert_called_once_with(self.dest, 'wb')


### PR DESCRIPTION
Python 3 returns a byte-string when calling read.