### PR TITLE
Safer in-place sed edits

### DIFF
--- a/packages/google-compute-engine/src/usr/bin/google_set_hostname
+++ b/packages/google-compute-engine/src/usr/bin/google_set_hostname
@@ -17,7 +17,7 @@
 
 if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then
   # Delete entries with new_host_name or new_ip_address in /etc/hosts.
-  sed -i '/Added by Google/d' /etc/hosts
+  sed -i"" '/Added by Google/d' /etc/hosts
 
   # Add an entry for our new_host_name/new_ip_address in /etc/hosts.
   echo "${new_ip_address} ${new_host_name} ${new_host_name%%.*}  # Added by Google" >> /etc/hosts

--- a/packages/google-compute-engine/src/usr/sbin/google-dhclient-script
+++ b/packages/google-compute-engine/src/usr/sbin/google-dhclient-script
@@ -85,7 +85,7 @@ eventually_add_hostnames_domain_to_search() {
 
        if [ "${is_in}" = "false" ]; then
           # Add domain name to search list (#637763)
-          sed -i -e "s/${search}/${search} ${domain}/" /etc/resolv.conf
+          sed -i"" -e "s/${search}/${search} ${domain}/" /etc/resolv.conf
        fi
     fi
 }


### PR DESCRIPTION
Replace invocations of `sed -i` with safer `sed -i""` in shell scripts