### PR TITLE
Separate continue call with startAlternate flag

### DIFF
--- a/packages/google-compute-engine-oslogin/pam_module/pam_oslogin_login.cc
+++ b/packages/google-compute-engine-oslogin/pam_module/pam_oslogin_login.cc
@@ -219,7 +219,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
   }
 
   if (challenge.status != "READY") {
-    // Call continueSession with startAlternate flag
+    // Call continueSession with the START_ALTERNATE flag.
     if (!ContinueSession(true, email, "", session_id, challenge, &response)) {
       PAM_SYSLOG(pamh, LOG_ERR,
                  "Bad response from two-factor continue session request: %s",

--- a/packages/google-compute-engine-oslogin/utils/oslogin_utils.cc
+++ b/packages/google-compute-engine-oslogin/utils/oslogin_utils.cc
@@ -612,7 +612,7 @@ bool StartSession(const string& email, string* response) {
   return ret;
 }
 
-bool ContinueSession(const string& email, const string& user_token,
+bool ContinueSession(bool alt, const string& email, const string& user_token,
                      const string& session_id, const Challenge& challenge,
                      string* response) {
   bool ret = true;
@@ -623,16 +623,20 @@ bool ContinueSession(const string& email, const string& user_token,
   json_object_object_add(jobj, "challengeId",
                          json_object_new_int(challenge.id));
 
-  if (challenge.type != AUTHZEN) {
+  if (alt) {
+    json_object_object_add(jobj, "action",
+                           json_object_new_string("START_ALTERNATE"));
+  } else {
+    json_object_object_add(jobj, "action",
+                           json_object_new_string("RESPOND"));
+  }
+
+  // AUTHZEN type and START_ALTERNATE action don't provide credentials.
+  if (challenge.type != AUTHZEN && !alt) {
     jresp = json_object_new_object();
     json_object_object_add(jresp, "credential",
                            json_object_new_string(user_token.c_str()));
     json_object_object_add(jobj, "proposalResponse", jresp);
-  }
-
-  if (challenge.status != "READY") {
-    json_object_object_add(jobj, "action",
-                           json_object_new_string("START_ALTERNATE"));
   }
 
   const char* data = NULL;
@@ -648,7 +652,8 @@ bool ContinueSession(const string& email, const string& user_token,
   }
 
   json_object_put(jobj);
-  if (challenge.type != AUTHZEN) {
+  // Match condition where we created this to avoid double-free.
+  if (challenge.type != AUTHZEN && !alt) {
     json_object_put(jresp);
   }
 

--- a/packages/google-compute-engine-oslogin/utils/oslogin_utils.h
+++ b/packages/google-compute-engine-oslogin/utils/oslogin_utils.h
@@ -193,7 +193,7 @@ bool ParseJsonToChallenges(const string& json, vector<Challenge> *challenges);
 bool StartSession(const string& email, string* response);
 
 // Calls the continueSession API.
-bool ContinueSession(const string& email, const string& user_token,
+bool ContinueSession(bool alt, const string& email, const string& user_token,
                      const string& session_id, const Challenge& challenge,
                      string* response);
 


### PR DESCRIPTION
The logic for multiple available challenges was not correctly handled - a START_ALTERNATE should only be sent when the chosen challenge is not status READY. This must be done separately from the continue call which includes the user token.

Tested with combinations of configured 2fa options, on Redhat and Debian