### PR TITLE
mv pam_group above pam_oslogin_login in auth stack

### DIFF
--- a/packages/google-compute-engine-oslogin/bin/google_oslogin_control
+++ b/packages/google-compute-engine-oslogin/bin/google_oslogin_control
@@ -185,11 +185,15 @@ modify_pam_sshd() (
   fi
 
   added_config="$added_comment"
-  if [ -n "$two_factor" ] && ! grep -qE '^auth.*oslogin' "$pam_config"; then
-    added_config="${added_config}\n${pam_auth_oslogin}"
-  fi
   if ! grep -qE '^auth.*pam_group' "$pam_config"; then
     added_config="${added_config}\n${pam_auth_group}"
+  fi
+
+  # This auth entry for OS Login+two factor MUST be added last, as it will
+  # short-circuit processing of the auth stack via [success=ok]. auth stack
+  # entries after this one will not be processed.
+  if [ -n "$two_factor" ] && ! grep -qE '^auth.*oslogin' "$pam_config"; then
+    added_config="${added_config}\n${pam_auth_oslogin}"
   fi
 
   # We can and should insert auth modules at top of `auth` stack.


### PR DESCRIPTION
IFF OS Login is initially set up with two factor authentication, the ordering of 2 entries in `/etc/pam.d/sshd:auth` is unintentionally reversed, leading to a short-circuit success of `pam_oslogin_login.so` prior to reaching the `pam_group.so` entry.

This is a fix which simply reverses the check ordering placing the optional short-circuit module second, so that no matter in what order you enable OS Login and two factor auth, you should always get the same ordering in the generated config file.