### PR TITLE
Bounce crond on OS Login control

### DIFF
--- a/packages/google-compute-engine-oslogin/bin/google_oslogin_control
+++ b/packages/google-compute-engine-oslogin/bin/google_oslogin_control
@@ -292,7 +292,7 @@ restart_sshd() {
 
 restart_svcs() {
   echo "Restarting optional services."
-  for svc in "nscd" "unscd" "systemd-logind"; do
+  for svc in "nscd" "unscd" "systemd-logind" "cron" "crond"; do
     restart_service "$svc"
   done
 }


### PR DESCRIPTION
Cron caches passwd lookups and should be included in the list of optional services to try restarting.