### PR TITLE
Fix platform detection in case of FreeBSD in compat module.

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/compat.py
+++ b/packages/python-google-compute-engine/google_compute_engine/compat.py
@@ -25,11 +25,17 @@ else:
   import platform as distro
 
 if 'freebsd' in sys.platform:
-  distribution = distro.version().split()
+  # Note: Do not use .version() method which is from either platform or distro
+  # platform.version() and distro.version() return different values.
+  # platform.version() returns 'FreeBSD 11.2-RELEASE-p9.....'
+  # distro.version() returns '11.2'
+  distro_name = 'freebsd'
+  # distro_version is not used for FreeBSD later in this code
+  distro_version = None
 else:
   distribution = distro.linux_distribution()
-distro_name = distribution[0].lower()
-distro_version = distribution[1].split('.')[0]
+  distro_name = distribution[0].lower()
+  distro_version = distribution[1].split('.')[0]
 distro_utils = None
 
 if 'centos' in distro_name and distro_version == '6':

--- a/packages/python-google-compute-engine/google_compute_engine/compat.py
+++ b/packages/python-google-compute-engine/google_compute_engine/compat.py
@@ -25,12 +25,12 @@ else:
   import platform as distro
 
 if 'freebsd' in sys.platform:
-  # Note: Do not use .version() method which is from either platform or distro
+  # Note: Do not use .version() method which is from either platform or distro.
   # platform.version() and distro.version() return different values.
-  # platform.version() returns 'FreeBSD 11.2-RELEASE-p9.....'
-  # distro.version() returns '11.2'
+  # platform.version() returns 'FreeBSD 11.2-RELEASE-p9.....'.
+  # distro.version() returns '11.2'.
   distro_name = 'freebsd'
-  # distro_version is not used for FreeBSD later in this code
+  # distro_version is not used for FreeBSD later in this code.
   distro_version = None
 else:
   distribution = distro.linux_distribution()

--- a/packages/python-google-compute-engine/google_compute_engine/tests/compat_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/tests/compat_test.py
@@ -109,10 +109,8 @@ class CompatTest(unittest.TestCase):
       self.assertEqual(
           test_cases[distro], google_compute_engine.compat.distro_utils)
 
-  @mock.patch('google_compute_engine.compat.sys.platform', 'freebsd')
-  @mock.patch('google_compute_engine.compat.distro.version')
-  def testDistroCompatFreeBSD(self, mock_call):
-    mock_call.return_value = 'FreeBSD 11.1-RELEASE-p4 #0: Tue Nov 14 06:12:40'
+  @mock.patch('google_compute_engine.compat.sys.platform', 'freebsd11')
+  def testDistroCompatFreeBSD(self):
     reload_import(google_compute_engine.compat)
     self.assertEqual(
         google_compute_engine.distro_lib.freebsd_11.utils,


### PR DESCRIPTION
Problem: For platform detection for Python >= 3.6 the `distro` package is used. For lower version of Python the built-in package `platform` is used.

`distro.linux_distribution()` is used to detect Linux
`distro.version()` is used to detecting FreeBSD

Method `distro.version()` should not be used because `distro` can be either `distro` itself or `import platform as distro`, therefore:

`platform.version()` and `distro.version()` return different values.
`platform.version()` returns 'FreeBSD 11.2-RELEASE-p9.....'
`distro.version()` returns '11.2'

Solution: Do not detect platform and version (in case of FreeBSD) using `distro` package, which is useful for linux but it's not necessary for FreeBSD.