### PR TITLE
Do not set up the boto config in Python 3.

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/constants.py
+++ b/packages/python-google-compute-engine/google_compute_engine/constants.py
@@ -16,6 +16,7 @@
 """A module for global constants."""
 
 import platform
+import sys
 
 OSLOGIN_CONTROL_SCRIPT = 'google_oslogin_control'
 OSLOGIN_NSS_CACHE_SCRIPT = 'google_oslogin_nss_cache'
@@ -41,3 +42,8 @@ else:
   OSLOGIN_NSS_CACHE = '/etc/oslogin_passwd.cache'
   SYSCONFDIR = '/etc/default'
   SYSLOG_SOCKET = '/dev/log'
+
+if sys.version_info >= (3, 0):
+  SET_BOTO_CONFIG = 'false'
+else:
+  SET_BOTO_CONFIG = 'true'

--- a/packages/python-google-compute-engine/google_compute_engine/instance_setup/instance_config.py
+++ b/packages/python-google-compute-engine/google_compute_engine/instance_setup/instance_config.py
@@ -78,7 +78,7 @@ class InstanceConfig(config_manager.ConfigManager):
           'host_key_types': 'ecdsa,ed25519,rsa',
           'optimize_local_ssd': 'true',
           'network_enabled': 'true',
-          'set_boto_config': 'true',
+          'set_boto_config': constants.SET_BOTO_CONFIG,
           'set_host_keys': 'true',
           'set_multiqueue': 'true',
       },


### PR DESCRIPTION
Users can override this value using the template config.