### PR TITLE
Disk expand: fixes for GPT

### DIFF
--- a/packages/gce-disk-expand/packaging/gce-disk-expand.spec
+++ b/packages/gce-disk-expand/packaging/gce-disk-expand.spec
@@ -13,7 +13,7 @@
 # limitations under the License.
 Name: gce-disk-expand
 Summary: Google Compute Engine root disk expansion module
-Version: 2.0.0
+Version: %{_version}
 Release: 1
 License: Apache Software License
 Group: System Environment/Base

--- a/packages/gce-disk-expand/packaging/setup_rpm.sh
+++ b/packages/gce-disk-expand/packaging/setup_rpm.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 NAME="gce-disk-expand"
-VERSION="2.0.0"
+VERSION="2.0.1"
 
 rpm_working_dir=/tmp/rpmpackage/
 working_dir=${PWD}
@@ -30,6 +30,8 @@ rm -rf ${rpm_working_dir}
 mkdir -p ${rpm_working_dir}/{SOURCES,SPECS}
 cp packaging/${NAME}.spec ${rpm_working_dir}/SPECS/
 
-tar czvf ${rpm_working_dir}/SOURCES/${NAME}_${VERSION}.orig.tar.gz  --exclude .git --exclude packaging --transform "s/^\./${NAME}-${VERSION}/" .
+tar czvf ${rpm_working_dir}/SOURCES/${NAME}_${VERSION}.orig.tar.gz  \
+  --exclude .git --exclude packaging --transform "s/^\./${NAME}-${VERSION}/" .
 
-rpmbuild --define "_topdir ${rpm_working_dir}/" -ba ${rpm_working_dir}/SPECS/${NAME}.spec
+rpmbuild --define "_topdir ${rpm_working_dir}/" --define "_version ${VERSION}" \
+  -ba ${rpm_working_dir}/SPECS/${NAME}.spec

--- a/packages/gce-disk-expand/src/expandfs-lib.sh
+++ b/packages/gce-disk-expand/src/expandfs-lib.sh
@@ -67,14 +67,15 @@ parted_fix_gpt() {
   local disk="$1"
   [ -z "$disk" ] && return
 
-  if parted -sm "$rootdisk" print 2>&1 | grep "fix the GPT"; then
+  if parted -sm "$disk" print 2>&1 | grep -q "fix the GPT"; then
     # Running parted prompts the user to fix this condition, but only does so in
     # the interactive exception handler. In order to pass input we must use the
     # hidden triple-dash flag and pass both print and Fix arguments. `print`
     # alone will not perform the fix, but `Fix` alone will fail the argument
     # parser.
-    parted -m ---pretend-input-tty "$rootdisk" print Fix
-    if parted -sm "$rootdisk" print 2>&1 | grep "fix the GPT"; then
+    parted -m ---pretend-input-tty "$disk" print Fix >/dev/null 2>&1 </dev/null
+    parted -m ---pretend-input-tty "$disk" print Fix >/dev/null 2>&1 </dev/null
+    if parted -sm "$disk" print 2>&1 | grep -q "fix the GPT"; then
       echo "Failed to fix the GPT."
       return 1
     fi
@@ -110,13 +111,13 @@ parted_needresize() {
     return 1
   fi
 
-  if ! echo -e "$out" | sed '$!d' | grep -q "^${partnum}:"; then
+  if ! printf "$out" | sed '$!d' | grep -q "^${partnum}:"; then
     echo "Root partition is not final partition on disk. Not resizing."
     return 1
   fi
 
-  disksize=$(echo -e "$out" | grep "^${disk}" | cut -d: -f2)
-  partend=$(echo -e "$out" | sed '$!d' | cut -d: -f4)
+  disksize=$(printf "$out" | grep "^${disk}" | cut -d: -f2)
+  partend=$(printf "$out" | sed '$!d' | cut -d: -f4)
   [ -n "$disksize" -a -n "$partend" ] || return 1
 
   disksize=${disksize%%B}
@@ -138,52 +139,3 @@ parted_resizepart() {
   fi
   udevadm settle
 }
-
-# Resizes partition by deleting and recreating with end position.
-# This is a subshell function to safeguard against modifications of IFS.
-parted_resize_mkpart() (
-  local disk="$1" partnum="$2"
-  [ -z "$disk" -o -z "$partnum" ] && return
-
-  local partnum="" partbegin="" partend="" partsize=""
-  local fstype="" partname="" flags="" temp=""
-
-  # $ parted -sm /dev/sda unit b print
-  # BYT;
-  # /dev/sda:18253611008B:scsi:512:4096:msdos:Google PersistentDisk:;
-  # 1:2097152B:18252611583B:18250514432B:ext4::boot;
-  #
-  if ! out=$(parted -sm "$disk" unit b print 2>&1); then
-    echo "Unable to get partition info."
-    return 1
-  fi
-
-  temp=/tmp/my_temp
-  echo -e "$out" | sed '$!d' > $temp
-  IFS=: read partnum partbegin partend partsize fstype partname flags < $temp
-  rm $temp
-
-  if ! out=$(parted -sm "$disk" rm $partnum 2>&1); then
-    echo "Failed to delete partition: ${out}"
-    return 1
-  fi
-
-  if ! out=$(parted -sm "$disk" -- mkpart pri $fstype $partbegin -1 2>&1); then
-    echo "Failed to recreate original partition: ${out}"
-    echo "Trying to create with original parameters."
-    if ! out=$(parted -sm "$disk" mkpart pri $fstype $partbegin $partend 2>&1); then
-      echo "Failed to recreate original partition: ${out}"
-      return 1
-    fi
-  fi
-
-  flags=${flags%%;}
-  IFS=,
-  for flag in $flags; do
-    if ! out=$(parted -sm "$disk" set $partnum $flag on 2>&1); then
-      echo "Failed to set \"$flag\" on ${disk} part ${partnum}: ${out}"
-      return 1
-    fi
-  done
-  udevadm settle
-)


### PR DESCRIPTION
The GPT fix needed to be cleaned up a bit - the partition change command will actually fail with this error which needs to be resolved, and then the command can be run again successfully. That's a painful workflow, I think we will probably replace `parted` with `sgdisk` for GPT partitions. This PR is pending successful workflow testing for all supported platforms, but works on the GCE CentOS7 UEFI image.