### PR TITLE
Allow OS login sudoers change GID too, not only UID

### DIFF
--- a/packages/google-compute-engine-oslogin/pam_module/pam_oslogin_admin.cc
+++ b/packages/google-compute-engine-oslogin/pam_module/pam_oslogin_admin.cc
@@ -86,7 +86,7 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc,
                  user_name);
       std::ofstream sudoers_file;
       sudoers_file.open(filename.c_str());
-      sudoers_file << user_name << " ALL=(ALL) NOPASSWD: ALL"
+      sudoers_file << user_name << " ALL=(ALL:ALL) NOPASSWD: ALL"
                    << "\n";
       sudoers_file.close();
       chown(filename.c_str(), 0, 0);


### PR DESCRIPTION
The rule as written allows sudoers change their UID, but not the GID, which after the change is necessarily that of the impersonated subject. I am herding a computing cluster with processes running under a small set of preset local UN*X identities. They all belong to the same primary group, the NFS filer maps nogroup to same; and, to have fewer permission surprises, I sudo me a shell to look as similar to these indefatigable AIs as possible (shh! they are so busy they do not even notice!). But as written, the rule requires an unwieldy 2-step sudo, to root first, and then to what I want to become second:
```
$ sudo sudo -u $(id -un) -g aisa id
uid=669822528(kkm_smartaction_ai) gid=60000(aisa) groups=60000(aisa),669822528
```

There is no security relaxation in this change: sudoers can become root, and the root can change to any UID/GID combination, as I do above.

I tested the change by modifying the drop-in sudoers snippet in /var/g-s.d/, and even added a little systemd .path-triggered service that sed(1)s files back into shape in case they get overwritten. But it's just a temporary hack, I hope.

It's also worth noting that, [apparently inconsistently](https://github.com/GoogleCloudPlatform/compute-image-packages/search?q=NOPASSWD), the non-os-login path (BYO SSH key) does permit sudoers to act at `(ALL:ALL)`:
https://github.com/GoogleCloudPlatform/compute-image-packages/blob/6767372dfedcb8ee52ed849732678e86e87657ae/packages/python-google-compute-engine/google_compute_engine/accounts/accounts_utils.py#L103-L105