### PR TITLE
Fix syslog output for metadata scripts for systemd.

### DIFF
--- a/packages/google-compute-engine/src/lib/systemd/system/google-instance-setup.service
+++ b/packages/google-compute-engine/src/lib/systemd/system/google-instance-setup.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Google Compute Engine Instance Setup
-After=network-online.target network.target
+After=network-online.target network.target rsyslog.service
 Before=sshd.service
 
 [Service]

--- a/packages/google-compute-engine/src/lib/systemd/system/google-shutdown-scripts.service
+++ b/packages/google-compute-engine/src/lib/systemd/system/google-shutdown-scripts.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Google Compute Engine Shutdown Scripts
-After=network-online.target network.target
+After=network-online.target network.target rsyslog.service
 After=google-instance-setup.service google-network-daemon.service
 
 [Service]

--- a/packages/google-compute-engine/src/lib/systemd/system/google-startup-scripts.service
+++ b/packages/google-compute-engine/src/lib/systemd/system/google-startup-scripts.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Google Compute Engine Startup Scripts
-After=network-online.target network.target
+After=network-online.target network.target rsyslog.service
 After=google-instance-setup.service google-network-daemon.service
 
 [Service]


### PR DESCRIPTION
- Put back removed systemd dependency so that script output is correctly logged to syslog when its available.