### PR TITLE
Fixbuild

### DIFF
--- a/packages/google-compute-engine-oslogin/src/Makefile
+++ b/packages/google-compute-engine-oslogin/src/Makefile
@@ -1,12 +1,12 @@
 SHELL = /bin/sh
 TOPDIR = $(realpath ..)
 
-VERSION = 20190711.00
+VERSION = 20190708.00
 
 CPPFLAGS = -Iinclude -I/usr/include/json-c
 FLAGS = -fPIC -Wall -g
 CFLAGS = $(FLAGS) -Wstrict-prototypes
-CXXFLAGS = $(FLAGS) -std=c++11
+CXXFLAGS = $(FLAGS)
 
 LDFLAGS = -shared -Wl,-soname,$(SONAME)
 LDLIBS = -lcurl -ljson-c
@@ -60,10 +60,10 @@ $(PAM_ADMIN) : pam/pam_oslogin_admin.o utils.o
 # Utilities.
 
 google_authorized_keys : authorized_keys/authorized_keys.o utils.o
-       $(CXX) $(CXXFLAGS) $(CPPFLAGS) -lboost_regex $^ -o $@ $(LDLIBS)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
 google_oslogin_nss_cache: cache_refresh/cache_refresh.o utils.o
-       $(CXX) $(CXXFLAGS) $(CPPFLAGS) -lboost_regex $^ -o $@ $(LDLIBS)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@ $(LDLIBS)
 
 install: all
 	install -d $(DESTDIR)$(LIBDIR)

--- a/packages/google-compute-engine-oslogin/src/include/oslogin_utils.h
+++ b/packages/google-compute-engine-oslogin/src/include/oslogin_utils.h
@@ -15,6 +15,7 @@
 #include <grp.h>
 #include <pthread.h>
 #include <pwd.h>
+#include <stdint.h>
 
 #include <string>
 #include <vector>

--- a/packages/google-compute-engine-oslogin/src/nss/nss_oslogin.cc
+++ b/packages/google-compute-engine-oslogin/src/nss/nss_oslogin.cc
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <syslog.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 #include <iostream>
 #include <sstream>

--- a/packages/google-compute-engine-oslogin/src/nss/nss_oslogin.cc
+++ b/packages/google-compute-engine-oslogin/src/nss/nss_oslogin.cc
@@ -147,7 +147,7 @@ enum nss_status _nss_oslogin_initgroups_dyn(const char *user, gid_t skipgroup,
   }
 
   gid_t *groups = *groupsp;
-  for (auto &group : grouplist) {
+  for (int i = 0; i < (int) grouplist.size(); i++) {
     // Resize the buffer if needed.
     if (*start == *size) {
       gid_t *newgroups;
@@ -168,7 +168,7 @@ enum nss_status _nss_oslogin_initgroups_dyn(const char *user, gid_t skipgroup,
       *groupsp = groups = newgroups;
       *size = newsize;
     }
-    groups[(*start)++] = group.gid;
+    groups[(*start)++] = grouplist[i].gid;
   }
   return NSS_STATUS_SUCCESS;
 }

--- a/packages/google-compute-engine-oslogin/src/utils.cc
+++ b/packages/google-compute-engine-oslogin/src/utils.cc
@@ -545,8 +545,8 @@ bool AddUsersToGroup(std::vector<string> users, struct group* result,
   }
   result->gr_mem = bufp;
 
-  for (auto& el : users) {
-    if (!buf->AppendString(el, bufp, errnop)) {
+  for (int i = 0; i < (int) users.size(); i++) {
+    if (!buf->AppendString(users[i], bufp, errnop)) {
       result->gr_mem = NULL;
       return false;
     }
@@ -689,7 +689,8 @@ bool FindGroup(struct group* result, BufferManager* buf, int* errnop) {
     }
 
     // Check for a match.
-    for (auto& el : groups) {
+    for (int i = 0; i < (int) groups.size(); i++) {
+      Group el = groups[i];
       if ((result->gr_name != NULL) && (string(result->gr_name) == el.name)) {
         // Set the name even though it matches because the final string must
         // be stored in the provided buffer.


### PR DESCRIPTION
Correct build errors for development branch. 

* Revert stdc++11 code; EL6 distros don't support it.
* Only link `lboost_regex` when needed.
* Some implicit function uses are errors on EL6 distros, add relevant includes.