### PR TITLE
Switch to the v1 Guest Attributes URL.

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/instance_setup/instance_setup.py
+++ b/packages/python-google-compute-engine/google_compute_engine/instance_setup/instance_setup.py
@@ -38,7 +38,7 @@ class PutRequest(urlrequest.Request):
     return 'PUT'
 
 
-GUEST_ATTRIBUTES_URL = ('http://metadata.google.internal/computeMetadata/v1beta1/'
+GUEST_ATTRIBUTES_URL = ('http://metadata.google.internal/computeMetadata/v1/'
                         'instance/guest-attributes')
 HOSTKEY_NAMESPACE = 'hostkeys'
 

--- a/packages/python-google-compute-engine/google_compute_engine/instance_setup/tests/instance_setup_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/instance_setup/tests/instance_setup_test.py
@@ -336,7 +336,7 @@ class InstanceSetupTest(unittest.TestCase):
     key_type = 'ssh-rsa'
     key_value = 'asdfasdf'
     encoded_key_value = key_value.encode('utf-8')
-    expected_url = ('http://metadata.google.internal/computeMetadata/v1beta1/'
+    expected_url = ('http://metadata.google.internal/computeMetadata/v1/'
                     'instance/guest-attributes/hostkeys/%s' % key_type)
     headers = {'Metadata-Flavor': 'Google'}
 


### PR DESCRIPTION
Now that Guest Attributes is out of beta, we can switch to the v1 URL.