### PR TITLE
Update script retrieval for Python 2 and 3.

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
@@ -112,12 +112,12 @@ class ScriptRetriever(object):
       request = urlrequest.Request(url)
       request.add_unredirected_header('Metadata-Flavor', 'Google')
       request.add_unredirected_header('Authorization', self.token)
-      content = _UrlOpenWithRetry(request).read().decode('utf-8')
+      content = _UrlOpenWithRetry(request).read()
     except Exception as e:
       self.logger.warning('Could not download %s. %s.', url, str(e))
       return None
 
-    with open(dest, 'w') as f:
+    with open(dest, 'wb') as f:
       f.write(content)
 
     return dest

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
@@ -59,10 +59,10 @@ class ScriptRetrieverTest(unittest.TestCase):
     mocked_request.add_unredirected_header.assert_called_with(
         'Authorization', 'bar')
     mock_urlopen.assert_called_with(mocked_request)
-    urlopen_read = mock_urlopen().read(return_value=b'foo').decode()
+    urlopen_read = mock_urlopen().read(return_value=b'foo')
     self.mock_logger.warning.assert_not_called()
 
-    mock_open.assert_called_once_with(self.dest, 'w')
+    mock_open.assert_called_once_with(self.dest, 'wb')
     handle = mock_open()
     handle.write.assert_called_once_with(urlopen_read)
 


### PR DESCRIPTION
Non-breaking spaces cause utf-8 encoding to fail during file writes.
Writing as bytes should be 2/3 compatible.