### PR TITLE
fix network restart loop

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/networking/network_daemon.py
+++ b/packages/python-google-compute-engine/google_compute_engine/networking/network_daemon.py
@@ -107,7 +107,7 @@ class NetworkDaemon(object):
       for interface in network_interfaces:
         self.ip_forwarding.HandleForwardedIps(
             interface.name, interface.forwarded_ips, interface.ip)
-    if socket.gethostname() != result['hostname'].split('.')[0]:
+    if socket.gethostname().split('.')[0] != result['hostname'].split('.')[0]:
       self.distro_utils.RestartNetworking(self.logger)
 
   def _ExtractInterfaceMetadata(self, metadata):


### PR DESCRIPTION
On some Linux distributions (we've observed this with some CentOS 6 version) gethostname() will return the fqdn of the instance, causing a continuous restart of the network. This will prevent this from happening by only taking the first part of the returned value into consideration.