### PR TITLE
Rollback VM rename

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/networking/network_daemon.py
+++ b/packages/python-google-compute-engine/google_compute_engine/networking/network_daemon.py
@@ -30,7 +30,6 @@ from google_compute_engine import file_utils
 from google_compute_engine import logger
 from google_compute_engine import metadata_watcher
 from google_compute_engine import network_utils
-from google_compute_engine.compat import distro_utils
 from google_compute_engine.networking.ip_forwarding import ip_forwarding
 from google_compute_engine.networking.network_setup import network_setup
 
@@ -40,7 +39,7 @@ LOCKFILE = constants.LOCALSTATEDIR + '/lock/google_networking.lock'
 class NetworkDaemon(object):
   """Manage networking based on changes to network metadata."""
 
-  instance_metadata_key = 'instance/'
+  network_interface_metadata_key = 'instance/network-interfaces'
 
   def __init__(
       self, ip_forwarding_enabled, proto_id, ip_aliases, target_instance_ips,
@@ -64,7 +63,6 @@ class NetworkDaemon(object):
     self.ip_forwarding_enabled = ip_forwarding_enabled
     self.network_setup_enabled = network_setup_enabled
     self.target_instance_ips = target_instance_ips
-    self.dhclient_script = dhclient_script
 
     self.ip_forwarding = ip_forwarding.IpForwarding(
         proto_id=proto_id, debug=debug)
@@ -72,7 +70,6 @@ class NetworkDaemon(object):
         dhclient_script=dhclient_script, dhcp_command=dhcp_command, debug=debug)
     self.network_utils = network_utils.NetworkUtils(logger=self.logger)
     self.watcher = metadata_watcher.MetadataWatcher(logger=self.logger)
-    self.distro_utils = distro_utils.Utils(debug=debug)
 
     try:
       with file_utils.LockFile(LOCKFILE):
@@ -80,7 +77,7 @@ class NetworkDaemon(object):
         timeout = 60 + random.randint(0, 30)
         self.watcher.WatchMetadata(
             self.HandleNetworkInterfaces,
-            metadata_key=self.instance_metadata_key, recursive=True,
+            metadata_key=self.network_interface_metadata_key, recursive=True,
             timeout=timeout)
     except (IOError, OSError) as e:
       self.logger.warning(str(e))
@@ -91,8 +88,7 @@ class NetworkDaemon(object):
     Args:
       result: dict, the metadata response with the network interfaces.
     """
-    network_interfaces = self._ExtractInterfaceMetadata(
-        result['networkInterfaces'])
+    network_interfaces = self._ExtractInterfaceMetadata(result)
 
     if self.network_setup_enabled:
       default_interface = network_interfaces[0]
@@ -107,8 +103,6 @@ class NetworkDaemon(object):
       for interface in network_interfaces:
         self.ip_forwarding.HandleForwardedIps(
             interface.name, interface.forwarded_ips, interface.ip)
-    if socket.gethostname() != result['hostname'].split('.')[0]:
-      self.distro_utils.RestartNetworking(self.logger)
 
   def _ExtractInterfaceMetadata(self, metadata):
     """Extracts network interface metadata.

--- a/packages/python-google-compute-engine/google_compute_engine/networking/tests/network_daemon_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/networking/tests/network_daemon_test.py
@@ -54,7 +54,7 @@ class NetworkDaemonTest(unittest.TestCase):
     mocks.attach_mock(mock_ip_forwarding, 'forwarding')
     mocks.attach_mock(mock_network_setup, 'network_setup')
     mocks.attach_mock(mock_watcher, 'watcher')
-    metadata_key = network_daemon.NetworkDaemon.instance_metadata_key
+    metadata_key = network_daemon.NetworkDaemon.network_interface_metadata_key
 
     with mock.patch.object(
         network_daemon.NetworkDaemon, 'HandleNetworkInterfaces'
@@ -129,13 +129,11 @@ class NetworkDaemonTest(unittest.TestCase):
       ]
       self.assertEqual(mocks.mock_calls, expected_calls)
 
-  @mock.patch('google_compute_engine.networking.network_daemon.distro_utils')
-  def testHandleNetworkInterfaces(self, mock_distro_utils):
+  def testHandleNetworkInterfaces(self):
     mocks = mock.Mock()
     mocks.attach_mock(self.mock_ip_forwarding, 'forwarding')
     mocks.attach_mock(self.mock_network_setup, 'network_setup')
     mocks.attach_mock(self.mock_setup, 'setup')
-    mocks.attach_mock(mock_distro_utils, 'distro_utils')
     self.mock_setup.ip_aliases = None
     self.mock_setup.target_instance_ips = None
     self.mock_setup.ip_forwarding_enabled = True
@@ -145,19 +143,17 @@ class NetworkDaemonTest(unittest.TestCase):
             'eth0', forwarded_ips=['a'], ip='1.1.1.1', ipv6=False),
         network_daemon.NetworkDaemon.NetworkInterface('eth1'),
     ]
-    self.mock_setup.distro_utils = mock.MagicMock()
-    result = mock.MagicMock()
+    result = mock.Mock()
 
     network_daemon.NetworkDaemon.HandleNetworkInterfaces(
         self.mock_setup, result)
     expected_calls = [
-        mock.call.setup._ExtractInterfaceMetadata(result['networkInterfaces']),
+        mock.call.setup._ExtractInterfaceMetadata(result),
         mock.call.network_setup.DisableIpv6(['eth0']),
         mock.call.network_setup.EnableNetworkInterfaces(['eth1']),
         mock.call.forwarding.HandleForwardedIps(
             'eth0', ['a'], '1.1.1.1'),
         mock.call.forwarding.HandleForwardedIps('eth1', None, None),
-        mock.call.setup.distro_utils.RestartNetworking(self.mock_setup.logger),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 
@@ -174,18 +170,16 @@ class NetworkDaemonTest(unittest.TestCase):
         network_daemon.NetworkDaemon.NetworkInterface(
             'eth0', forwarded_ips=['a'], ip='1.1.1.1', ipv6=True),
     ]
-    self.mock_setup.distro_utils = mock.MagicMock()
-    result = mock.MagicMock()
+    result = mock.Mock()
 
     network_daemon.NetworkDaemon.HandleNetworkInterfaces(
         self.mock_setup, result)
     expected_calls = [
-        mock.call.setup._ExtractInterfaceMetadata(result['networkInterfaces']),
+        mock.call.setup._ExtractInterfaceMetadata(result),
         mock.call.network_setup.EnableIpv6(['eth0']),
         mock.call.network_setup.EnableNetworkInterfaces([]),
         mock.call.forwarding.HandleForwardedIps(
             'eth0', ['a'], '1.1.1.1'),
-        mock.call.setup.distro_utils.RestartNetworking(self.mock_setup.logger),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 
@@ -202,18 +196,16 @@ class NetworkDaemonTest(unittest.TestCase):
         network_daemon.NetworkDaemon.NetworkInterface(
             'eth0', forwarded_ips=['a'], ip='1.1.1.1', ipv6=False),
     ]
-    self.mock_setup.distro_utils = mock.MagicMock()
-    result = mock.MagicMock()
+    result = mock.Mock()
 
     network_daemon.NetworkDaemon.HandleNetworkInterfaces(
         self.mock_setup, result)
     expected_calls = [
-        mock.call.setup._ExtractInterfaceMetadata(result['networkInterfaces']),
+        mock.call.setup._ExtractInterfaceMetadata(result),
         mock.call.network_setup.DisableIpv6(['eth0']),
         mock.call.network_setup.EnableNetworkInterfaces([]),
         mock.call.forwarding.HandleForwardedIps(
             'eth0', ['a'], '1.1.1.1'),
-        mock.call.setup.distro_utils.RestartNetworking(self.mock_setup.logger),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 
@@ -230,14 +222,12 @@ class NetworkDaemonTest(unittest.TestCase):
         network_daemon.NetworkDaemon.NetworkInterface('a'),
         network_daemon.NetworkDaemon.NetworkInterface('b'),
     ]
-    self.mock_setup.distro_utils = mock.MagicMock()
-    result = mock.MagicMock()
+    result = mock.Mock()
 
     network_daemon.NetworkDaemon.HandleNetworkInterfaces(
         self.mock_setup, result)
     expected_calls = [
-        mock.call.setup._ExtractInterfaceMetadata(result['networkInterfaces']),
-        mock.call.setup.distro_utils.RestartNetworking(self.mock_setup.logger),
+        mock.call.setup._ExtractInterfaceMetadata(result),
     ]
     self.assertEqual(mocks.mock_calls, expected_calls)
 


### PR DESCRIPTION
This feature has been flaky for users and difficult to debug; rolling back for now.