### PR TITLE
small fixups

### DIFF
--- a/packages/google-compute-engine/src/lib/systemd/system/google-accounts-daemon.service
+++ b/packages/google-compute-engine/src/lib/systemd/system/google-accounts-daemon.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Google Compute Engine Accounts Daemon
-After=network.target google-instance-setup.service google-network-daemon.service
+After=network.target google-instance-setup.service google-network-daemon.service sssd.service
 
 [Service]
 Type=simple

--- a/packages/google-compute-engine/src/usr/bin/google_set_multiqueue
+++ b/packages/google-compute-engine/src/usr/bin/google_set_multiqueue
@@ -115,6 +115,7 @@ done
 # If we have more CPUs than queues, then stripe CPUs across tx affinity
 # as CPUNumber % queue_count.
 for q in $XPS; do
+  [[ -f $q ]] || continue
   queue_re=".*tx-([0-9]+).*$"
   if [[ "$q" =~ ${queue_re} ]]; then
     queue_num=${BASH_REMATCH[1]}

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
@@ -216,7 +216,7 @@ class ScriptRetriever(object):
       self.logger.info('Found %s in metadata.', metadata_key)
       with tempfile.NamedTemporaryFile(
           mode='w', dir=dest_dir, delete=False) as dest:
-        dest.write(metadata_value.lstrip())
+        dest.write(str(metadata_value.lstrip().encode('utf-8')))
         script_dict[metadata_key] = dest.name
 
     metadata_key = '%s-script-url' % self.script_type


### PR DESCRIPTION
* Force UTF-8 encoding during script writing to disk; fixes an unreported bug on SLES12 when non-ASCII characters (smart quote, em dash, etc.) are contained in startup scripts.
* Check for CPU entry before amending when setting multiqueue; fixes a non-blocking error
* Add ordering without declaring a dependency for google-accounts-daemon on SSSD; fixes #854