### PR TITLE
Add retry count to metadata update loop

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
@@ -154,7 +154,7 @@ class MetadataWatcher(object):
 
   def _HandleMetadataUpdate(
       self, metadata_key='', recursive=True, wait=True, timeout=None,
-      retry=True):
+      retry=True, retry_limit=50):
     """Wait for a successful metadata response.
 
     Args:
@@ -163,12 +163,14 @@ class MetadataWatcher(object):
       wait: bool, True if we should wait for a metadata change.
       timeout: int, timeout in seconds for returning metadata output.
       retry: bool, True if we should retry on failure.
+      retry_limit: int, number of times to retry obtaining metadata.
 
     Returns:
       json, the deserialized contents of the metadata server.
     """
     exception = None
-    while True:
+    retry_count = 0
+    while retry_count < retry_limit:
       try:
         return self._GetMetadataUpdate(
             metadata_key=metadata_key, recursive=recursive, wait=wait,
@@ -178,6 +180,7 @@ class MetadataWatcher(object):
           exception = e
           self.logger.error('GET request error retrieving metadata. %s.', e)
         if retry:
+          retry_count += 1
           continue
         else:
           break


### PR DESCRIPTION
This is in response to issue #862 opened by @rjschwei 

Added a retry counter with a default of 50 tries before breaking the loop.
