### PR TITLE
Added retry loop to _HandleMetadataUpdate

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
@@ -168,7 +168,7 @@ class MetadataWatcher(object):
       json, the deserialized contents of the metadata server.
     """
     exception = None
-    while retries > 0:
+    while retries > -1:
       try:
         return self._GetMetadataUpdate(
             metadata_key=metadata_key, recursive=recursive, wait=wait,

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
@@ -154,7 +154,7 @@ class MetadataWatcher(object):
 
   def _HandleMetadataUpdate(
       self, metadata_key='', recursive=True, wait=True, timeout=None,
-      retry=True):
+      retries=5):
     """Wait for a successful metadata response.
 
     Args:
@@ -162,13 +162,13 @@ class MetadataWatcher(object):
       recursive: bool, True if we should recursively watch for metadata changes.
       wait: bool, True if we should wait for a metadata change.
       timeout: int, timeout in seconds for returning metadata output.
-      retry: bool, True if we should retry on failure.
+      retries: int, Number of times to retry obtaining metadata.
 
     Returns:
       json, the deserialized contents of the metadata server.
     """
     exception = None
-    while True:
+    while retries > 0:
       try:
         return self._GetMetadataUpdate(
             metadata_key=metadata_key, recursive=recursive, wait=wait,
@@ -177,10 +177,8 @@ class MetadataWatcher(object):
         if not isinstance(e, type(exception)):
           exception = e
           self.logger.error('GET request error retrieving metadata. %s.', e)
-        if retry:
-          continue
-        else:
-          break
+        time.sleep(1)
+        continue
 
   def WatchMetadata(
       self, handler, metadata_key='', recursive=True, timeout=None):
@@ -202,7 +200,7 @@ class MetadataWatcher(object):
         self.logger.exception('Exception calling the response handler. %s.', e)
 
   def GetMetadata(
-      self, metadata_key='', recursive=True, timeout=None, retry=True):
+      self, metadata_key='', recursive=True, timeout=None, retries=5):
     """Retrieve the contents of metadata server for a metadata key.
 
     Args:
@@ -216,4 +214,4 @@ class MetadataWatcher(object):
     """
     return self._HandleMetadataUpdate(
         metadata_key=metadata_key, recursive=recursive, wait=False,
-        timeout=timeout, retry=retry)
+        timeout=timeout, retries=retries)

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
@@ -168,7 +168,7 @@ class MetadataWatcher(object):
       json, the deserialized contents of the metadata server.
     """
     exception = None
-    while retries > -1:
+    while retries >= 0:
       try:
         return self._GetMetadataUpdate(
             metadata_key=metadata_key, recursive=recursive, wait=wait,

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
@@ -156,7 +156,7 @@ class MetadataWatcher(object):
       self, metadata_key='', recursive=True, wait=True, timeout=None,
       retries=5):
     """Wait for a successful metadata response.
-    
+
     Args:
       metadata_key: string, the metadata key to watch for changes.
       recursive: bool, True if we should recursively watch for metadata changes.

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
@@ -156,7 +156,7 @@ class MetadataWatcher(object):
       self, metadata_key='', recursive=True, wait=True, timeout=None,
       retries=5):
     """Wait for a successful metadata response.
-
+    
     Args:
       metadata_key: string, the metadata key to watch for changes.
       recursive: bool, True if we should recursively watch for metadata changes.

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
@@ -179,7 +179,6 @@ class MetadataWatcher(object):
           exception = e
           self.logger.error('GET request error retrieving metadata. %s.', e)
         time.sleep(1)
-        continue
 
   def WatchMetadata(
       self, handler, metadata_key='', recursive=True, timeout=None):

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_watcher.py
@@ -174,6 +174,7 @@ class MetadataWatcher(object):
             metadata_key=metadata_key, recursive=recursive, wait=wait,
             timeout=timeout)
       except (httpclient.HTTPException, socket.error, urlerror.URLError) as e:
+        retries -= 1
         if not isinstance(e, type(exception)):
           exception = e
           self.logger.error('GET request error retrieving metadata. %s.', e)

--- a/packages/python-google-compute-engine/google_compute_engine/tests/metadata_watcher_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/tests/metadata_watcher_test.py
@@ -342,15 +342,15 @@ class MetadataWatcherTest(unittest.TestCase):
     self.mock_watcher._HandleMetadataUpdate = mock_response
     metadata_key = 'instance/id'
     recursive = False
-    retry = False
+    retries = 5
 
     response = self.mock_watcher.GetMetadata(
         metadata_key=metadata_key, recursive=recursive, timeout=60,
-        retry=retry)
+        retries=retries)
     self.assertEqual(response, {})
     mock_response.assert_called_once_with(
         metadata_key=metadata_key, recursive=False, wait=False, timeout=60,
-        retry=False)
+        retries=None)
     self.mock_watcher.logger.exception.assert_not_called()
 
 

--- a/packages/python-google-compute-engine/google_compute_engine/tests/metadata_watcher_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/tests/metadata_watcher_test.py
@@ -333,7 +333,7 @@ class MetadataWatcherTest(unittest.TestCase):
 
     self.assertEqual(self.mock_watcher.GetMetadata(), {})
     mock_response.assert_called_once_with(
-        metadata_key='', recursive=True, wait=False, timeout=None, retry=True)
+        metadata_key='', recursive=True, wait=False, timeout=None, retries=0)
     self.mock_watcher.logger.exception.assert_not_called()
 
   def testGetMetadataArgs(self):
@@ -350,7 +350,7 @@ class MetadataWatcherTest(unittest.TestCase):
     self.assertEqual(response, {})
     mock_response.assert_called_once_with(
         metadata_key=metadata_key, recursive=False, wait=False, timeout=60,
-        retries=None)
+        retries=0)
     self.mock_watcher.logger.exception.assert_not_called()
 
 

--- a/packages/python-google-compute-engine/google_compute_engine/tests/metadata_watcher_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/tests/metadata_watcher_test.py
@@ -259,12 +259,12 @@ class MetadataWatcherTest(unittest.TestCase):
     metadata_key = 'instance/id'
     recursive = False
     wait = False
-    retry = True
+    retries = 5
 
     self.assertEqual(
         self.mock_watcher._HandleMetadataUpdate(
             metadata_key=metadata_key, recursive=recursive, wait=wait,
-            timeout=None, retry=retry),
+            timeout=None, retries=retries),
         {})
     expected_calls = [
         mock.call(
@@ -282,12 +282,12 @@ class MetadataWatcherTest(unittest.TestCase):
     metadata_key = 'instance/id'
     recursive = False
     wait = False
-    retry = False
+    retries = 5
 
     self.assertIsNone(
         self.mock_watcher._HandleMetadataUpdate(
             metadata_key=metadata_key, recursive=recursive, wait=wait,
-            timeout=None, retry=retry))
+            timeout=None, retries=retries))
     expected_calls = [
         mock.call(
             metadata_key=metadata_key, recursive=recursive, wait=wait,

--- a/packages/python-google-compute-engine/google_compute_engine/tests/metadata_watcher_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/tests/metadata_watcher_test.py
@@ -282,7 +282,7 @@ class MetadataWatcherTest(unittest.TestCase):
     metadata_key = 'instance/id'
     recursive = False
     wait = False
-    retries = 5
+    retries = 0
 
     self.assertIsNone(
         self.mock_watcher._HandleMetadataUpdate(
@@ -333,7 +333,7 @@ class MetadataWatcherTest(unittest.TestCase):
 
     self.assertEqual(self.mock_watcher.GetMetadata(), {})
     mock_response.assert_called_once_with(
-        metadata_key='', recursive=True, wait=False, timeout=None, retries=0)
+        metadata_key='', recursive=True, wait=False, timeout=None, retries=5)
     self.mock_watcher.logger.exception.assert_not_called()
 
   def testGetMetadataArgs(self):
@@ -350,7 +350,7 @@ class MetadataWatcherTest(unittest.TestCase):
     self.assertEqual(response, {})
     mock_response.assert_called_once_with(
         metadata_key=metadata_key, recursive=False, wait=False, timeout=60,
-        retries=0)
+        retries=5)
     self.mock_watcher.logger.exception.assert_not_called()
 
 


### PR DESCRIPTION
This is in response to issue #862 opened by @rjschwei

Added a retry counter with a default of 50 tries before breaking the loop.