### PR TITLE
Add a missed change for retries

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/script_retriever.py
@@ -97,7 +97,7 @@ class ScriptRetriever(object):
 
     if not self.token:
       response = self.watcher.GetMetadata(
-          self.token_metadata_key, recursive=False, retry=False)
+          self.token_metadata_key, recursive=False, retries=1)
 
       if not response:
         self.logger.info(

--- a/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/metadata_scripts/tests/script_retriever_test.py
@@ -89,7 +89,7 @@ class ScriptRetrieverTest(unittest.TestCase):
     # GetMetadata includes a prefix, so remove it.
     stripped_url = token_url.replace(metadata_prefix, '')
     mock_get_metadata.assert_called_once_with(
-        stripped_url, recursive=False, retry=False)
+        stripped_url, recursive=False, retries=1)
 
     self.assertEqual(self.retriever.token, 'foo bar')
 
@@ -119,7 +119,7 @@ class ScriptRetrieverTest(unittest.TestCase):
     prefix = 'http://metadata.google.internal/computeMetadata/v1/'
     stripped_url = token_url.replace(prefix, '')
     mock_get_metadata.assert_called_once_with(
-        stripped_url, recursive=False, retry=False)
+        stripped_url, recursive=False, retries=1)
     mock_download_url.assert_called_once_with(auth_url, self.dest_dir)
 
     self.assertIsNone(self.retriever.token)


### PR DESCRIPTION
Add a change that was missed in #864; causes metadata script runners to fail