### PR TITLE
version bump for revert

### DIFF
--- a/packages/python-google-compute-engine/packaging/debian/changelog
+++ b/packages/python-google-compute-engine/packaging/debian/changelog
@@ -1,3 +1,9 @@
+python-google-compute-engine (1:20191120.00-g1) stable; urgency=medium
+
+  * REVERT: Retry metadata lookups in agent.
+
+ -- Google Cloud Team <gc-team@google.com>  Wed, 20 Sep 2019 15:28:54 -0700
+
 python-google-compute-engine (1:20191115.00-g1) stable; urgency=medium
 
   * REVERT: Enable sysctl change for E2 platform.

--- a/packages/python-google-compute-engine/packaging/setup_deb.sh
+++ b/packages/python-google-compute-engine/packaging/setup_deb.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 NAME="python-google-compute-engine"
-VERSION="20191115.00"
+VERSION="20191120.00"
 
 working_dir=${PWD}
 if [[ $(basename "$working_dir") != $NAME ]]; then

--- a/packages/python-google-compute-engine/packaging/setup_rpm.sh
+++ b/packages/python-google-compute-engine/packaging/setup_rpm.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 NAME="python-google-compute-engine"
-VERSION="20191115.00"
+VERSION="20191120.00"
 
 rpm_working_dir=/tmp/rpmpackage/${NAME}-${VERSION}
 working_dir=${PWD}


### PR DESCRIPTION
Should not need to change anything in `google-compute-engine` package any longer as we previously broken the version lock between these. 