### PR TITLE
Travis CI: sudo is deprecated and Xenial is default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: python
-sudo: true
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
-matrix:
-  include:
-  - python: 3.7
-    dist: xenial
+- 3.7
+- 3.8
 os:
 - linux
 install:


### PR DESCRIPTION
Add Python 3.8 and remove the EOL Python 3.4.