### PR TITLE
ensure hwclock always uses utc when syncing hardware to system clock

### DIFF
--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/helpers.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/helpers.py
@@ -115,7 +115,7 @@ def CallHwclock(logger):
   Args:
     logger: logger object, used to write to SysLog and serial port.
   """
-  command = ['/sbin/hwclock', '--hctosys']
+  command = ['/sbin/hwclock', '--hctosys', '--utc']
   try:
     subprocess.check_call(command)
   except subprocess.CalledProcessError:

--- a/packages/python-google-compute-engine/google_compute_engine/distro_lib/tests/helpers_test.py
+++ b/packages/python-google-compute-engine/google_compute_engine/distro_lib/tests/helpers_test.py
@@ -153,7 +153,7 @@ class HelpersTest(unittest.TestCase):
 
   @mock.patch('google_compute_engine.distro_lib.helpers.subprocess.check_call')
   def testCallHwclock(self, mock_call):
-    command = ['/sbin/hwclock', '--hctosys']
+    command = ['/sbin/hwclock', '--hctosys', '--utc']
     mock_logger = mock.Mock()
 
     helpers.CallHwclock(mock_logger)
@@ -163,7 +163,7 @@ class HelpersTest(unittest.TestCase):
 
   @mock.patch('google_compute_engine.distro_lib.helpers.subprocess.check_call')
   def testCallHwclockError(self, mock_call):
-    command = ['/sbin/hwclock', '--hctosys']
+    command = ['/sbin/hwclock', '--hctosys', '--utc']
     mock_logger = mock.Mock()
     mock_call.side_effect = subprocess.CalledProcessError(1, 'Test')
 


### PR DESCRIPTION
Possibly resolves #554 