### PR TITLE
Fix race condition with udev device settlement.

### DIFF
--- a/packages/gce-disk-expand/src/expandfs-lib.sh
+++ b/packages/gce-disk-expand/src/expandfs-lib.sh
@@ -69,6 +69,7 @@ sgdisk_get_label() {
     else
         echo "gpt"
     fi
+    udevadm settle
 }
 
 sgdisk_fix_gpt() {
@@ -79,6 +80,7 @@ sgdisk_fix_gpt() {
   [ "$label" != "gpt" ] && return
 
   sgdisk --move-second-header "$disk"
+  udevadm settle
 }
 
 # Returns "disk:partition", supporting multiple block types.

--- a/packages/gce-disk-expand/src/expandfs-lib.sh
+++ b/packages/gce-disk-expand/src/expandfs-lib.sh
@@ -47,6 +47,7 @@ resize_filesystem() {
 blkid_get_fstype() (
     local root="$1"
 
+    udevadm settle
     if ! out=$(blkid -o udev "$root"); then
         echo "Detecting fstype by blkid failed: ${out}"
         return 1
@@ -62,6 +63,8 @@ blkid_get_fstype() (
 
 sgdisk_get_label() {
     local root="$1"
+
+    udevadm settle
     [ -z "$root" ] && return 0
 
     if sgdisk -p "$root" | grep -q "Found invalid GPT and valid MBR"; then
@@ -69,7 +72,6 @@ sgdisk_get_label() {
     else
         echo "gpt"
     fi
-    udevadm settle
 }
 
 sgdisk_fix_gpt() {
@@ -86,6 +88,8 @@ sgdisk_fix_gpt() {
 # Returns "disk:partition", supporting multiple block types.
 split_partition() {
   local root="$1" disk="" partnum=""
+
+  udevadm settle
   [ -z "$root" ] && return 0
 
   if [ -e /sys/block/${root##*/} ]; then

--- a/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/install
+++ b/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/install
@@ -28,5 +28,4 @@ dracut_install grep
 dracut_install resize2fs
 dracut_install e2fsck
 dracut_install udevadm
-dracut_install systemctl
 dracut_install -o xfs_growfs

--- a/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/install
+++ b/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/install
@@ -28,4 +28,5 @@ dracut_install grep
 dracut_install resize2fs
 dracut_install e2fsck
 dracut_install udevadm
+dracut_install systemctl
 dracut_install -o xfs_growfs


### PR DESCRIPTION
Before every use of the $root variable, make sure that udev has settled enumeration. Otherwise, the device links that $root refers to may not exist.