### PR TITLE
Interim fix fo EL7 GPT header move race condition with systemd-fsck.

### DIFF
--- a/packages/gce-disk-expand/packaging/debian/changelog
+++ b/packages/gce-disk-expand/packaging/debian/changelog
@@ -1,3 +1,9 @@
+gce-disk-expand (1:20200428.00-g1) stable; urgency=medium
+
+  * Fix potential races in disk expand logic with GPT disks.
+
+ -- Google Cloud Team <gc-team@google.com>  Tue, 28 Apr 2020 10:24:07 -0700
+
 gce-disk-expand (1:20190708.00-g1) stable; urgency=medium
 
   * Update disk expand to fix bugs with GPT.

--- a/packages/gce-disk-expand/packaging/setup_deb.sh
+++ b/packages/gce-disk-expand/packaging/setup_deb.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 NAME="gce-disk-expand"
-VERSION="20190708.00"
+VERSION="20200428.00"
 
 working_dir=${PWD}
 if [[ $(basename "$working_dir") != $NAME ]]; then

--- a/packages/gce-disk-expand/packaging/setup_rpm.sh
+++ b/packages/gce-disk-expand/packaging/setup_rpm.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 NAME="gce-disk-expand"
-VERSION="20190708.00"
+VERSION="20200428.00"
 
 rpm_working_dir=/tmp/rpmpackage/
 working_dir=${PWD}

--- a/packages/gce-disk-expand/src/expandfs-lib.sh
+++ b/packages/gce-disk-expand/src/expandfs-lib.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 kmsg() {
-  echo "expand_rootfs: $@" > /dev/kmsg
+  echo "gce-disk-expand: $@" > /dev/kmsg
 }
 
 resize_filesystem() {
@@ -84,6 +84,7 @@ sgdisk_fix_gpt() {
   local label=$(sgdisk_get_label "$disk")
   [ "$label" != "gpt" ] && return
 
+  # TODO Find a better solution than sleep.
   # Add sleeps to allow this operation to fully complete. On some systems, other
   # operations such as systemd-fsck tasks can collide and fail.
   udevadm settle

--- a/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/expand_rootfs.sh
+++ b/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/expand_rootfs.sh
@@ -22,9 +22,6 @@
 # logged, rather than causing end of execution. Note that error handling in the
 # main() function always calls return 0
 
-kmsg() {
-  echo "expand_rootfs: $@" > /dev/kmsg
-}
 
 main() {
   local disk="" partnum="" fs_type="" rootdev=""
@@ -69,7 +66,7 @@ main() {
   fi
 
   if ! out=$(resize_filesystem "$rootdev"); then
-    kmsg "Failed to resize filesystem: ${out}"
+    kmsg "Not resizing filesystem: ${out}"
     return
   fi
 }

--- a/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/install
+++ b/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/install
@@ -28,5 +28,4 @@ dracut_install grep
 dracut_install resize2fs
 dracut_install e2fsck
 dracut_install udevadm
-dracut_install systemctl
 dracut_install -o xfs_growfs

--- a/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/install
+++ b/packages/gce-disk-expand/src/usr/share/dracut/modules.d/50expand_rootfs/install
@@ -28,4 +28,5 @@ dracut_install grep
 dracut_install resize2fs
 dracut_install e2fsck
 dracut_install udevadm
+dracut_install systemctl
 dracut_install -o xfs_growfs


### PR DESCRIPTION
This race manifests depending on how quickly the system boots and is more prevalent on some faster systems. When running the GPT move header operation multiple systemd-fsck tasks are spawned because of device enumeration. These can overrun each other and cause failures. Adding a sleep before and after this operation resolves the race. But we should find another solution that doesn't rely on sleep if possible.

Also add better console logging messages to the steps being run.