### PR TITLE
Fix typo in new repo link

### DIFF
--- a/packages/google-compute-engine/README.md
+++ b/packages/google-compute-engine/README.md
@@ -1,4 +1,4 @@
 ## Google Compute Engine configuration and utilities package
 
 **This package has moved. The google-compute-engine package is now located in
-the [guest-config](https://github.com/GoogleCloudPlatform/guest-config) repo**
+the [guest-configs](https://github.com/GoogleCloudPlatform/guest-configs) repo**


### PR DESCRIPTION
Moved package to new repo has broken link (missing s)